### PR TITLE
fix: emit lowercase for shifted alpha keys

### DIFF
--- a/packages/machine-pcg815/src/machine.ts
+++ b/packages/machine-pcg815/src/machine.ts
@@ -383,6 +383,9 @@ export class PCG815Machine implements MachinePCG815, Bus {
     if (shiftActive && shifted !== undefined) {
       return shifted & 0xff;
     }
+    if (shiftActive && normal >= 0x41 && normal <= 0x5a) {
+      return (normal + 0x20) & 0xff;
+    }
     return normal & 0xff;
   }
 

--- a/packages/machine-pcg815/tests/machine.test.ts
+++ b/packages/machine-pcg815/tests/machine.test.ts
@@ -275,6 +275,17 @@ describe('PCG815Machine', () => {
     expect(String.fromCharCode(code)).toBe('P');
   });
 
+  it('generates lowercase letters when SHIFT is pressed with A-Z keys', () => {
+    const machine = new PCG815Machine();
+
+    machine.setKeyState('ShiftLeft', true);
+    machine.setKeyState('KeyA', true);
+    machine.setKeyState('KeyA', false);
+    machine.setKeyState('ShiftLeft', false);
+
+    expect(machine.in8(0x12)).toBe('a'.charCodeAt(0));
+  });
+
   it('generates ASCII queue from extended key codes (JIS + numpad)', () => {
     const machine = new PCG815Machine();
 


### PR DESCRIPTION
## Summary
- update keyboard ASCII resolution so `SHIFT + A-Z` emits lowercase (`a-z`) when a key does not define an explicit shifted symbol
- keep existing shifted symbol behavior unchanged for keys that already provide `shifted` mappings (digits and punctuation)
- add regression test that verifies lowercase output via the keyboard ASCII FIFO

## Testing
- `npm run test --workspace @z80emu/machine-pcg815`
- `npm run test`
- `npm run test:e2e`
