### PR TITLE
fix: stabilize basic editor run and wait behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ npm install
 npm run dev
 ```
 
+## Browser BASIC Editor
+
+- 右側の `BASIC Editor` にプログラムを入力し、`RUN Program` で実行します
+- 実行シーケンスは `NEW -> program lines -> RUN`（既定）です
+- `STOP CPU` はエミュレータCPU実行を停止します（暴走時の退避用）
+- `Load Sample` は `WAIT/IF THEN` を含むカウントアップサンプルを読み込みます
+
+### 既知ギャップ（MVP）
+
+- 保存/読込（`.bas`）は未実装
+- 差分送信RUNは未実装（毎回 `NEW` で全行再投入）
+- エミュレータ内実行のみ対応（実機転送は対象外）
+
 ## ワークスペース構成
 
 - `apps/web`: ViteベースのWebアプリ（Canvas2D UI）

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -42,6 +42,50 @@
         </section>
 
         <section class="status-panel">
+          <section class="basic-editor-panel" aria-label="BASIC editor">
+            <div class="basic-editor-head">
+              <h2>BASIC Editor</h2>
+              <span id="basic-run-status" class="basic-run-status" role="status" aria-live="polite">Idle</span>
+            </div>
+            <p class="basic-editor-hint">
+              Editor focus: keyboard input types into this editor. Outside editor focus: keys control the emulator.
+              RUN executes: NEW -> program lines -> RUN.
+            </p>
+            <p class="basic-editor-ref">
+              Language reference:
+              <a
+                href="https://github.com/yappo/z80emuweb/blob/main/docs/basic-language-spec.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                >basic-language-spec.md</a
+              >
+            </p>
+            <div class="basic-editor-body">
+              <pre id="basic-editor-lines" class="basic-editor-lines" aria-hidden="true">1</pre>
+              <textarea
+                id="basic-editor"
+                class="basic-editor"
+                spellcheck="false"
+                autocapitalize="off"
+                autocomplete="off"
+                aria-label="BASIC source editor"
+              >10 A = 1
+20 PRINT A
+30 A = A + 1
+40 WAIT 64
+50 IF A > 10 THEN 70
+60 GOTO 20
+70 PRINT "owari"
+80 END</textarea>
+            </div>
+            <div class="basic-editor-controls" role="group" aria-label="BASIC editor controls">
+              <button id="basic-run" type="button">RUN Program</button>
+              <button id="basic-stop" type="button">STOP CPU</button>
+              <button id="basic-new" type="button">NEW</button>
+              <button id="basic-load-sample" type="button">Load Sample</button>
+            </div>
+          </section>
+
           <h2>Status</h2>
           <pre id="debug-view" class="debug-view" hidden></pre>
           <h3>Input Log</h3>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -190,6 +190,113 @@ button[data-active='1'] {
   align-content: start;
 }
 
+.basic-editor-panel {
+  margin: 0;
+  padding: 0.65rem;
+  border-radius: 8px;
+  border: 1px solid #b9a68a;
+  background: color-mix(in oklab, var(--panel), white 20%);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.basic-editor-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.45rem;
+}
+
+.basic-run-status {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.72rem;
+  color: #2f251a;
+  background: #e8dec8;
+  border: 1px solid #b9a68a;
+  border-radius: 999px;
+  padding: 0.1rem 0.45rem;
+}
+
+.basic-run-status[data-state='running'] {
+  color: #204020;
+  background: #d9ecd4;
+  border-color: #7ba06f;
+}
+
+.basic-run-status[data-state='failed'] {
+  color: #6e1f1f;
+  background: #f5d9d9;
+  border-color: #b45f5f;
+}
+
+.basic-run-status[data-state='ok'] {
+  color: #244020;
+  background: #e0f0dd;
+  border-color: #72926c;
+}
+
+.basic-editor-hint {
+  margin: 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.basic-editor-ref {
+  margin: 0;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.basic-editor-ref a {
+  color: #244020;
+}
+
+.basic-editor-body {
+  border: 1px solid #b9a68a;
+  border-radius: 8px;
+  background: #f4ecdc;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.basic-editor-lines {
+  margin: 0;
+  padding: 0.5rem 0.35rem;
+  min-width: 2.2rem;
+  text-align: right;
+  color: #7a6651;
+  background: #e5d8c0;
+  border-right: 1px solid #c2ae8f;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  user-select: none;
+  overflow: hidden;
+}
+
+.basic-editor {
+  resize: vertical;
+  min-height: 180px;
+  margin: 0;
+  border: 0;
+  outline: none;
+  padding: 0.5rem 0.6rem;
+  background: transparent;
+  color: #2a2118;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.basic-editor-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .status-panel h2,
 .status-panel h3 {
   margin: 0;

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -23,6 +23,15 @@ test('app boots and renders lit LCD pixels without runtime errors', async ({ pag
   await expect(page.getByRole('button', { name: 'Reset' })).toBeVisible();
   await expect(page.getByRole('button', { name: /かな OFF/i })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Fonts' })).toBeVisible();
+  await expect(page.locator('#basic-editor')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'RUN Program' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'STOP CPU' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'NEW' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Load Sample' })).toBeVisible();
+  await expect(page.locator('.basic-editor-hint')).toContainText(/Editor focus:/i);
+  await page.locator('#basic-editor').click();
+  await page.keyboard.type('30 PRINT 654');
+  await expect(page.locator('#basic-editor')).toHaveValue(/30 PRINT 654/);
 
   await expect(page.locator('#boot-status')).toContainText(/READY/i, { timeout: 5_000 });
   await expect(page.locator('#boot-status')).toContainText(/strict=0/i);
@@ -34,8 +43,8 @@ test('app boots and renders lit LCD pixels without runtime errors', async ({ pag
   await expect(page.locator('#font-kana-canvas')).toBeVisible();
 
   // Stop CPU loop so ASCII FIFO is not consumed by runtime while testing input mapping.
-  await page.getByRole('button', { name: 'Stop' }).click();
-  await expect(page.getByRole('button', { name: 'Run' })).toBeVisible();
+  await page.getByRole('button', { name: 'Stop', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Run', exact: true })).toBeVisible();
 
   const kanaToggle = page.getByRole('button', { name: /かな OFF/i });
   await kanaToggle.click();
@@ -152,11 +161,9 @@ test('app boots and renders lit LCD pixels without runtime errors', async ({ pag
     )
     .toBeGreaterThan(0);
 
-  await page.evaluate(() => {
-    (window as { __pcg815?: { injectBasicLine: (line: string) => void } }).__pcg815?.injectBasicLine(
-      'PRINT 321'
-    );
-  });
+  await page.locator('#basic-editor').fill('10 PRINT 321\n20 END');
+  await page.getByRole('button', { name: 'RUN Program' }).click();
+  await expect(page.locator('#basic-run-status')).toContainText(/Run OK/i, { timeout: 5_000 });
 
   await expect
     .poll(
@@ -178,6 +185,57 @@ test('app boots and renders lit LCD pixels without runtime errors', async ({ pag
 
   expect(pageErrors).toEqual([]);
   expect(consoleErrors).toEqual([]);
+});
+
+test('basic editor handles syntax error and reset rerun flow', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#boot-status')).toContainText(/READY/i, { timeout: 5_000 });
+
+  await page.locator('#basic-editor').fill('10 GOTO 9999\n20 END');
+  await page.getByRole('button', { name: 'RUN Program' }).click();
+  await expect(page.locator('#basic-run-status')).toContainText(/Failed:/i, { timeout: 5_000 });
+
+  await page.locator('#basic-editor').fill('10 PRINT 999\n20 END');
+  await page.getByRole('button', { name: 'RUN Program' }).click();
+  await expect(page.locator('#basic-run-status')).toContainText(/Run OK/i, { timeout: 5_000 });
+
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() => {
+          const api = window as { __pcg815?: { getTextLines: () => string[] } };
+          return (api.__pcg815?.getTextLines() ?? []).join('\n');
+        }),
+      { timeout: 5_000, intervals: [100, 250, 500] }
+    )
+    .toContain('999');
+
+  await page.getByRole('button', { name: 'STOP CPU' }).click();
+  await expect(page.locator('#basic-run-status')).toContainText(/Stopped/i);
+});
+
+test('basic editor can rerun after STOP CPU with WAIT program', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#boot-status')).toContainText(/READY/i, { timeout: 5_000 });
+
+  await page.locator('#basic-editor').fill('10 PRINT 1\n20 WAIT 64\n30 PRINT 2\n40 END');
+  await page.getByRole('button', { name: 'RUN Program' }).click();
+  await page.getByRole('button', { name: 'STOP CPU' }).click();
+  await expect(page.locator('#basic-run-status')).toContainText(/Stopped/i, { timeout: 5_000 });
+
+  await page.getByRole('button', { name: 'RUN Program' }).click();
+  await expect(page.locator('#basic-run-status')).toContainText(/Run OK/i, { timeout: 5_000 });
+
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() => {
+          const api = window as { __pcg815?: { getTextLines: () => string[] } };
+          return (api.__pcg815?.getTextLines() ?? []).join('\n');
+        }),
+      { timeout: 5_000, intervals: [100, 250, 500] }
+    )
+    .toContain('2');
 });
 
 test('strict URL parameter enables strict boot mode diagnostics', async ({ page }) => {

--- a/packages/machine-pcg815/src/machine.ts
+++ b/packages/machine-pcg815/src/machine.ts
@@ -354,6 +354,7 @@ export class PCG815Machine implements MachinePCG815, Bus {
     const clamped = Math.max(0, Math.floor(tstates));
     this.cpu.stepTState(clamped);
     this.elapsedTStates += clamped;
+    this.runtime.pump();
   }
 
   setKeyState(code: string, pressed: boolean): void {
@@ -399,6 +400,10 @@ export class PCG815Machine implements MachinePCG815, Bus {
 
   getKanaMode(): boolean {
     return this.kanaMode;
+  }
+
+  isRuntimeProgramRunning(): boolean {
+    return this.runtime.isProgramRunning();
   }
 
   getTextLines(): string[] {
@@ -845,12 +850,8 @@ export class PCG815Machine implements MachinePCG815, Bus {
       out8: (port: number, value: number) => this.out8(port, value),
       peek8: (address: number) => this.read8(address),
       poke8: (address: number, value: number) => this.write8(address, value),
-      sleepMs: (ms: number) => {
-        const deadline = Date.now() + Math.max(0, Math.trunc(ms));
-        while (Date.now() < deadline) {
-          // 同期待機で BEEP/WAIT の体感を再現する。
-        }
-      }
+      // 非ブロッキング方針: WAIT/BEEP でメインスレッドを塞がない。
+      sleepMs: (_ms: number) => {}
     };
   }
 }

--- a/packages/machine-pcg815/src/types.ts
+++ b/packages/machine-pcg815/src/types.ts
@@ -30,6 +30,7 @@ export interface MachinePCG815 {
   setKeyState(code: string, pressed: boolean): void;
   setKanaMode(enabled: boolean): void;
   getKanaMode(): boolean;
+  isRuntimeProgramRunning(): boolean;
   getFrameBuffer(): Uint8Array;
   reset(cold: boolean): void;
 }


### PR DESCRIPTION
## Summary
- add BASIC editor reference link and update default sample program
- make WAIT/BEEP non-blocking while preserving delayed progression in RUN programs
- fix rerun issue after STOP CPU by auto-resuming CPU loop and waiting for runtime completion
- improve editor keyboard focus behavior and add status handling for stop/timeout

## Changes
- apps/web: UI updates, run flow stabilization, runtime completion wait loop, stop token cancellation
- firmware-monitor: cooperative RUN pump with WAIT/BEEP delay signal handling
- machine-pcg815: expose runtime running state and pump on tick
- tests: add regression for `RUN -> STOP CPU -> RUN` with WAIT program

## Verification
- npm run test
- npm run test:e2e
