### PR TITLE
refactor: migrate emulator stack to pin-driven chipset architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
    - 必要に応じて不具合再現/修正確認コマンドを実行して正常に動作することを確認する
 5. コミットメッセージは `type: summary` 形式（英語・命令形）を必須とします。`type` は `fix|refactor|test|docs|chore`。例: `fix: validate required -d option in mergepos`
 6. PRは `gh` コマンドで作成し、本文は次のテンプレートを必須とします。
-   - `gh pr create --base master --head <branch> --title \"<title>\" --body-file <file>`
+   - `gh pr create --base main --head <branch> --title \"<title>\" --body-file <file>`
 7. PR作成後は GitHub Actions の CI を確認し、**必須ジョブが全て成功してから** merge します。失敗していたら gh コマンドで CI のログを確認し原因を調査しコミットを再度行います (`gh run view <run-id> --log-failed`)
    - `gh pr checks <pr-number> --watch`
    - `gh pr merge <pr-number> --merge --delete-branch`

--- a/README.md
+++ b/README.md
@@ -50,10 +50,12 @@ npm run dev
 
 - `apps/web`: ViteベースのWebアプリ（Canvas2D UI）
 - `packages/assembler-z80`: Web/CLI共通のZ80アセンブラ
-- `packages/core-z80`: T-state単位で進むZ80コア
+- `packages/core-z80`: pin入出力 + T-state 単位で進むZ80コア
+- `packages/machine-chipsets`: CPU pin とマシンデバイスを接続する中間層
 - `packages/machine-pcg815`: マシン層（メモリマップ、LCD、キーボード）
 - `packages/firmware-monitor`: モニタ + 小規模BASICランタイム
 - `docs/hardware-spec.md`: ハード仕様前提とマッピング
+- `docs/hardware-layer-overview.md`: 端末 - chipset - CPU の接続レイヤー概要
 - `docs/z80-cpu-spec-sheet.md`: Z80 CPU 命令・レジスタ・割り込み・I/O 仕様（実装ベース）
 - `docs/basic-language-spec.md`: 現行 BASIC 言語仕様と未実装コマンド一覧
 - `docs/assembly-language-spec.md`: アセンブラ文法・ディレクティブ・出力仕様

--- a/apps/web/src/asm-sample-repro.test.ts
+++ b/apps/web/src/asm-sample-repro.test.ts
@@ -29,7 +29,7 @@ function tapKey(machine: PCG815Machine, code: string): void {
 }
 
 describe('asm sample input flow', () => {
-  it('reads input and prints reversed text', () => {
+  it('reads input and prints reversed text', { timeout: 20_000 }, () => {
     const mainTs = readFileSync(path.resolve(process.cwd(), 'src/main.ts'), 'utf8');
     const asm = extractAsmSample(mainTs);
     const assembled = assemble(asm, { filename: 'asm-sample.asm' });

--- a/apps/web/src/asm-sample-repro.test.ts
+++ b/apps/web/src/asm-sample-repro.test.ts
@@ -28,16 +28,6 @@ function tapKey(machine: PCG815Machine, code: string): void {
   runFor(machine, 1024);
 }
 
-function setSp(machine: PCG815Machine, sp: number): void {
-  const cpu = (machine as { cpu?: { getState: () => any; loadState: (state: any) => void } }).cpu;
-  if (!cpu) {
-    throw new Error('cpu internals unavailable');
-  }
-  const state = cpu.getState();
-  state.registers.sp = sp & 0xffff;
-  cpu.loadState(state);
-}
-
 describe('asm sample input flow', () => {
   it('reads input and prints reversed text', () => {
     const mainTs = readFileSync(path.resolve(process.cwd(), 'src/main.ts'), 'utf8');
@@ -49,7 +39,7 @@ describe('asm sample input flow', () => {
     const machine = new PCG815Machine({ strictCpuOpcodes: true });
     machine.reset(true);
     machine.loadProgram(assembled.binary, assembled.origin);
-    setSp(machine, 0x7ffe);
+    machine.setStackPointer(0x7ffe);
     machine.setProgramCounter(assembled.entry);
 
     runFor(machine, 50_000);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
     alias: {
       '@z80emu/core-z80': path.resolve(__dirname, '../../packages/core-z80/src/index.ts'),
       '@z80emu/firmware-monitor': path.resolve(__dirname, '../../packages/firmware-monitor/src/index.ts'),
+      '@z80emu/machine-chipsets': path.resolve(
+        __dirname,
+        '../../packages/machine-chipsets/src/index.ts'
+      ),
       '@z80emu/assembler-z80': path.resolve(__dirname, '../../packages/assembler-z80/src/index.ts'),
       '@z80emu/machine-pcg815': path.resolve(
         __dirname,

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,16 @@
 import { defineConfig } from 'vitest/config';
+import path from 'node:path';
 
 export default defineConfig({
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.json'],
+    alias: {
+      '@z80emu/core-z80': path.resolve(__dirname, '../../packages/core-z80/src/index.ts'),
+      '@z80emu/firmware-monitor': path.resolve(__dirname, '../../packages/firmware-monitor/src/index.ts'),
+      '@z80emu/machine-chipsets': path.resolve(__dirname, '../../packages/machine-chipsets/src/index.ts'),
+      '@z80emu/machine-pcg815': path.resolve(__dirname, '../../packages/machine-pcg815/src/index.ts')
+    }
+  },
   test: {
     include: ['src/**/*.test.ts'],
     passWithNoTests: true

--- a/docs/hardware-layer-overview.md
+++ b/docs/hardware-layer-overview.md
@@ -1,0 +1,163 @@
+# PC-G815互換 エミュレータ ハードウェア層概要
+
+この文書は、現在の実装で「どの層が何を担当し、どの線で繋がっているか」を、人間が追える言葉で説明するための概要です。  
+対象は Web 版エミュレータです。
+
+## 1. まず全体像
+
+エミュレータの中では、次の順で責務を分けています。
+
+1. 端末層: 画面を描き、キー入力を受ける
+2. マシン層: RAM/ROM/LCD/キーボード状態を持つ
+3. chipset層: CPU の pin 信号を読み解いて、メモリ/I/O に橋渡しする
+4. CPU層: Z80 命令を 1T ずつ実行して pin 信号を出す
+
+```mermaid
+flowchart LR
+  UI["端末層\nWeb UI (画面・キー入力・実行ボタン)"]
+  MACH["マシン層\nPCG815Machine\n(RAM/ROM/LCD/キーボード状態を保持)"]
+  CHIP["chipset層\nBasicChipset\n(CPU pin とメモリ/I/Oを仲介)"]
+  CPU["CPU層\nZ80Cpu\n(命令実行と pin 出力)"]
+  FW["ファームウェア層\nMonitorRuntime / ROM"]
+
+  UI -->|"tick・キー入力・状態取得"| MACH
+  MACH -->|"memory / io デバイスを登録"| CHIP
+  CHIP -->|"Z80PinsIn を渡す"| CPU
+  CPU -->|"Z80PinsOut を返す"| CHIP
+  MACH <-->|"machine adapter 経由"| FW
+```
+
+
+### `pin` とは何か
+
+この文書でいう `pin` は、CPU の外に出ている「信号線」を意味します。  
+実機のCPUチップにある足（ピン）を、ソフトウェア上でモデル化したものです。
+
+ポイントは次の3つです。
+
+1. CPU はメモリを直接読み書きしない  
+   CPU は「このアドレスを読みたい」「このポートへ書きたい」という意図を、`mreq` / `iorq` / `rd` / `wr` / `addr` / `dataOut` で外へ出します。
+
+2. 外側（chipset）が pin を見て実処理する  
+   `BasicChipset` が pin 信号を読み取り、`read8` / `write8` / `in8` / `out8` を呼び出します。
+
+3. 1Tごとに pin が変わる  
+   命令は一気に終わるのではなく、T-state ごとに pin が遷移します。  
+   この遷移を追えるようにすると、WAIT や割り込み受理タイミングを正確に再現できます。
+
+### pin 信号一覧（早見表）
+
+| 信号名 | 向き | 何を表すか | 主に使われる場面 |
+|---|---|---|---|
+| `addr` | CPU→外部 | 対象アドレス/ポート番号 | メモリ read/write、I/O read/write、命令フェッチ |
+| `dataOut` | CPU→外部 | CPUが外へ書き出す1バイト値 | メモリ書き込み、I/O書き込み |
+| `data` | 外部→CPU | CPUが外部から受け取る1バイト値 | メモリ読み出し、I/O読み出し、INT ACK |
+| `mreq` | CPU→外部 | メモリアクセス要求 | 命令フェッチ、メモリ read/write |
+| `iorq` | CPU→外部 | I/Oアクセス要求 | `IN` / `OUT`、INT ACK |
+| `rd` | CPU→外部 | 読み取り動作 | メモリ読み出し、I/O読み出し、INT ACK |
+| `wr` | CPU→外部 | 書き込み動作 | メモリ書き込み、I/O書き込み |
+| `m1` | CPU→外部 | 命令フェッチ系サイクル | opcode fetch、INT ACK の先頭 |
+| `rfsh` | CPU→外部 | リフレッシュサイクル | 命令フェッチ後半 |
+| `wait` | 外部→CPU | 現在のバスサイクルを待たせる | 低速デバイス待ち合わせ |
+| `int` | 外部→CPU | マスク可能割り込み要求 | 命令境界で受理判定 |
+| `nmi` | 外部→CPU | ノンマスク割り込み要求 | 最優先割り込み |
+| `reset` | 外部→CPU | CPUリセット要求 | 初期化、再起動 |
+| `halt` | CPU→外部 | HALT状態で停止中か | 割り込み待ち状態 |
+| `busrq` | 外部→CPU | バス使用権要求 | DMA相当のバス譲渡要求（将来拡張） |
+| `busak` | CPU→外部 | バス使用権を譲渡中か | `busrq` への応答（将来拡張） |
+
+## 2. 各層の責務
+
+| 層 | 主コンポーネント | 主責務 | 下位層との接続 |
+|---|---|---|---|
+| 端末層 | Web UI（Canvas/Key入力/Editor） | 画面描画、キーイベント、実行操作 | `PCG815Machine` API を呼ぶ |
+| マシン層 | `PCG815Machine` | RAM/ROM/LCD/Keyboard/I/Oレジスタ管理、スナップショット管理 | `BasicChipset` に memory/io を登録 |
+| chipset層 | `BasicChipset` | CPU pin 解釈、メモリ/I/O ルーティング、INT/WAIT/RESET 等入力供給 | `Z80Core.tick()` を T-state 単位で駆動 |
+| CPU層 | `Z80Cpu` | 命令デコード、M/T サイクル進行、pin出力生成 | `Z80PinsIn/Out` 契約でのみ通信 |
+| firmware層 | `MonitorRuntime` + ROM | BASIC/モニタ動作ロジック | machine adapter 経由でマシン資源を操作 |
+
+## 3. 何がどこを通るか
+
+### 3.1 メモリ読み書きの流れ
+
+1. CPU が `mreq + rd` を出すと「メモリ読み取り要求」
+2. chipset がアドレスを見て `read8(addr)` を呼ぶ
+3. 読み出した値を `data` として CPU に返す
+4. CPU が `mreq + wr` を出すと「メモリ書き込み要求」
+5. chipset が `write8(addr, value)` を呼ぶ
+
+### 3.2 I/O 読み書きの流れ
+
+1. CPU が `iorq + rd` を出すと「I/O読み取り」
+2. chipset が `in8(port)` を呼ぶ
+3. CPU が `iorq + wr` を出すと「I/O書き込み」
+4. chipset が `out8(port, value)` を呼ぶ
+
+### 3.3 割り込みの流れ
+
+1. マシン層が I/O レジスタ状態から「INT が必要か」を判断
+2. chipset が次の `tick` 入力で `int=true` を CPU に渡す
+3. CPU は命令境界で受理し、INT ACK サイクルへ入る
+
+```mermaid
+flowchart TD
+  CPU["CPU (Z80Cpu)"] -->|"mreq/iorq + rd/wr + addr + dataOut"| CHIP["chipset (BasicChipset)"]
+  CHIP -->|"read8 / write8"| MEM["メモリデバイス\nRAM/ROM window"]
+  CHIP -->|"in8 / out8"| IO["I/Oデバイス\nキーボード/LCD/システムポート"]
+  MEM -->|"読み出し値"| CHIP
+  IO -->|"読み出し値"| CHIP
+  CHIP -->|"data / int / wait など"| CPU
+```
+
+## 4. 1T ごとに何が起きるか
+
+`tick(1)` の最小単位で見ると、毎回ほぼ同じ手順を回します。
+
+1. 前の T で出た pin を見て、必要ならメモリ/I/O に read/write を実行
+2. `data/int/wait` など入力 pin を組み立てる
+3. CPU に 1T 分 `tick(input)` を渡す
+4. CPU が次の T で使う pin 出力を返す
+
+```mermaid
+sequenceDiagram
+  participant UI as 端末層
+  participant M as PCG815Machine
+  participant C as BasicChipset
+  participant D as メモリ/I/O
+  participant Z as Z80Cpu
+
+  UI->>M: tick(n)
+  loop n 回
+    M->>C: tick(1)
+    C->>D: 前回 pin に基づく read/write
+    C->>Z: Z80PinsIn を渡す
+    Z-->>C: Z80PinsOut を返す
+  end
+  M-->>UI: CPU状態・LCD状態を更新
+```
+
+## 5. 具体例: キー入力から画面更新まで
+
+「A キーを押して、画面に文字が出る」までを簡単に追うと次の流れです。
+
+1. 端末層がキー押下イベントを受ける  
+2. マシン層のキーマトリクス状態が更新される  
+3. CPU が I/O 読み取り命令でキーボードポートを読む  
+4. chipset が `in8(port)` を呼び、キーマトリクス値を返す  
+5. CPU/ランタイムが文字として処理し、LCD 用の I/O 書き込みを行う  
+6. マシン層の LCD バッファが更新され、端末層が描画する  
+
+## 6. 接続を理解するための最小用語
+
+- `tick`: 1 ステップ進める呼び出し
+- `T-state (1T)`: CPU の最小時間単位
+- `pin`: CPU 外部信号（`mreq`, `iorq`, `rd`, `wr`, `data` など）
+- `memory device`: RAM/ROM を読む・書く窓
+- `io device`: ポート入出力を扱う窓
+- `chipset`: pin 信号とデバイス呼び出しを変換する仲介層
+
+## 7. この設計にした理由
+
+1. CPU 実装とマシン実装を分離し、見通しを良くするため  
+2. サイクル精度のテストを CPU 単体で書きやすくするため  
+3. 将来、別のマシン構成に差し替えやすくするため  

--- a/docs/z80-cpu-spec-sheet.md
+++ b/docs/z80-cpu-spec-sheet.md
@@ -277,32 +277,9 @@
 
 ## 10. 未実装命令の現況（2026-02-21時点）
 
-`strictUnsupportedOpcodes=true` で全空間（base/CB/ED/DD/FD/DDCB/FDCB）を走査しても
-`Unsupported opcode` は発生しません。
-
-今回の拡張で以下を追加し、予約/未定義 opcode は NOP 相当として扱う実装に整理しました。
-
-- ベース空間:
-  - `LD r,r'` 群
-  - `ADD/ADC/SUB/SBC/AND/XOR/OR/CP r,(HL),(IX+d),(IY+d)` 群
-  - `DJNZ`, `EXX`, `EX AF,AF'`, `EX (SP),HL/IX/IY`, `JP (HL/IX/IY)`, `LD SP,HL/IX/IY`
-  - `RLCA/RRCA/RLA/RRA`, `DAA/CPL/SCF/CCF`
-- CB 空間:
-  - `RRC`, `RR`, `SLA`, `SRA`, `SLL`, `SRL`（`r/(HL)/(IX+d)/(IY+d)`）
-- ED 空間:
-  - `IN r,(C)`, `OUT (C),r`
-  - `ADC HL,rr`, `SBC HL,rr`
-  - `LD (nn),rr`, `LD rr,(nn)`
-  - `IM 0/1/2`
-  - `RRD/RLD`
-  - `LDI/LDD/LDIR/LDDR`
-  - `CPI/CPD/CPIR/CPDR`
-  - `INI/IND/INIR/INDR`
-  - `OUTI/OUTD/OTIR/OTDR`
-
-注:
-- 「予約/未定義 opcode が存在しない」という意味ではなく、
-  CPU 実装上はそれらも実行可能（NOP 相当）として扱う、という意味です。
+- 現時点で「未実装」として明示している命令はありません。
+- ただし、実機仕様上の予約/未定義 opcode の厳密挙動は未確定です。
+  現在の実装では、これらを NOP 相当として継続実行します。
 
 ## 11. 参照ファイル
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1264,6 +1264,10 @@
       "resolved": "packages/firmware-monitor",
       "link": true
     },
+    "node_modules/@z80emu/machine-chipsets": {
+      "resolved": "packages/machine-chipsets",
+      "link": true
+    },
     "node_modules/@z80emu/machine-pcg815": {
       "resolved": "packages/machine-pcg815",
       "link": true
@@ -3111,12 +3115,20 @@
       "name": "@z80emu/firmware-monitor",
       "version": "0.1.0"
     },
+    "packages/machine-chipsets": {
+      "name": "@z80emu/machine-chipsets",
+      "version": "0.1.0",
+      "dependencies": {
+        "@z80emu/core-z80": "file:../core-z80"
+      }
+    },
     "packages/machine-pcg815": {
       "name": "@z80emu/machine-pcg815",
       "version": "0.1.0",
       "dependencies": {
         "@z80emu/core-z80": "file:../core-z80",
-        "@z80emu/firmware-monitor": "file:../firmware-monitor"
+        "@z80emu/firmware-monitor": "file:../firmware-monitor",
+        "@z80emu/machine-chipsets": "file:../machine-chipsets"
       }
     }
   }

--- a/packages/core-z80/src/index.ts
+++ b/packages/core-z80/src/index.ts
@@ -1,3 +1,4 @@
 // core-z80 パッケージの公開 API 入口。
 export * from './types';
 export * from './z80-cpu';
+export * from './timing-definitions';

--- a/packages/core-z80/src/timing-definitions.ts
+++ b/packages/core-z80/src/timing-definitions.ts
@@ -1,0 +1,20 @@
+export type OpcodeSpace = 'base' | 'cb' | 'ed' | 'dd' | 'fd' | 'ddcb' | 'fdcb';
+
+// Phase 1: opcode 空間ごとに「timing 定義が存在するか」を固定するレジストリ。
+// 詳細な M/T ステート列は次段で各 opcode 個別定義へ置換する。
+const FULLY_DEFINED_SPACE = Object.freeze(Array.from({ length: 0x100 }, (_v, opcode) => opcode));
+
+export const Z80_TIMING_DEFINITION_TABLE: Readonly<Record<OpcodeSpace, readonly number[]>> = Object.freeze({
+  base: FULLY_DEFINED_SPACE,
+  cb: FULLY_DEFINED_SPACE,
+  ed: FULLY_DEFINED_SPACE,
+  dd: FULLY_DEFINED_SPACE,
+  fd: FULLY_DEFINED_SPACE,
+  ddcb: FULLY_DEFINED_SPACE,
+  fdcb: FULLY_DEFINED_SPACE
+});
+
+export function hasTimingDefinition(space: OpcodeSpace, opcode: number): boolean {
+  const clamped = opcode & 0xff;
+  return Z80_TIMING_DEFINITION_TABLE[space].includes(clamped);
+}

--- a/packages/core-z80/src/z80-cpu.ts
+++ b/packages/core-z80/src/z80-cpu.ts
@@ -9,12 +9,28 @@ import {
   FLAG_Z,
   parity8
 } from './flags';
-import type { Bus, Cpu, CpuRegisters, CpuShadowRegisters, CpuState, InterruptMode } from './types';
+import {
+  Z80_IDLE_PINS_OUT,
+  type CpuRegisters,
+  type CpuShadowRegisters,
+  type CpuState,
+  type InterruptMode,
+  type Z80Core,
+  type Z80PinsIn,
+  type Z80PinsOut
+} from './types';
 
 type IndexMode = 'HL' | 'IX' | 'IY';
-type TStateOp = () => void;
 type RotateOp = 'RLC' | 'RL' | 'RRC' | 'RR' | 'SLA' | 'SRA' | 'SLL' | 'SRL';
 type Alu8Op = 'ADD' | 'ADC' | 'SUB' | 'SBC' | 'AND' | 'XOR' | 'OR' | 'CP';
+type TStateOp = (input: Z80PinsIn) => void;
+type PinsProducer = Z80PinsOut | (() => Z80PinsOut);
+
+interface TStateStep {
+  pins: PinsProducer;
+  waitable?: boolean;
+  action?: TStateOp;
+}
 
 export interface Z80CpuOptions {
   strictUnsupportedOpcodes?: boolean;
@@ -61,13 +77,24 @@ function overflowSub8(left: number, right: number, result: number): boolean {
   return (((left ^ right) & (left ^ result) & 0x80) !== 0);
 }
 
-export class Z80Cpu implements Cpu {
-  private readonly bus: Bus;
+function normalizePinsIn(input: Z80PinsIn): Z80PinsIn {
+  return {
+    data: clamp8(input.data),
+    wait: Boolean(input.wait),
+    int: Boolean(input.int),
+    nmi: Boolean(input.nmi),
+    busrq: Boolean(input.busrq),
+    reset: Boolean(input.reset)
+  };
+}
 
+export class Z80Cpu implements Z80Core {
   private readonly options: Z80CpuOptions;
 
   // 1 T-state ごとに消費するマイクロオペレーション列。
-  private readonly queue: TStateOp[] = [];
+  private readonly queue: TStateStep[] = [];
+
+  private pinsOut: Z80PinsOut = { ...Z80_IDLE_PINS_OUT };
 
   private readonly regs: CpuRegisters = {
     a: 0,
@@ -105,21 +132,25 @@ export class Z80Cpu implements Cpu {
 
   private halted = false;
 
+  private pendingInt = false;
+
   private pendingIntDataBus: number | undefined;
 
   private pendingNmi = false;
+
+  private prevNmi = false;
 
   private deferInterruptAcceptance = false;
 
   private tstates = 0;
 
-  constructor(bus: Bus, options?: Z80CpuOptions) {
-    this.bus = bus;
+  constructor(options?: Z80CpuOptions) {
     this.options = options ?? {};
   }
 
   reset(): void {
     this.queue.length = 0;
+    this.pinsOut = { ...Z80_IDLE_PINS_OUT };
     this.regs.a = 0;
     this.regs.f = 0;
     this.regs.b = 0;
@@ -146,34 +177,56 @@ export class Z80Cpu implements Cpu {
     this.iff2 = false;
     this.im = 1;
     this.halted = false;
+    this.pendingInt = false;
     this.pendingIntDataBus = undefined;
     this.pendingNmi = false;
+    this.prevNmi = false;
     this.deferInterruptAcceptance = false;
     this.tstates = 0;
   }
 
-  stepTState(count: number): void {
-    for (let i = 0; i < count; i += 1) {
-      // 命令デコードは queue が空になったタイミングでのみ行う。
-      if (this.queue.length === 0) {
-        this.scheduleNextInstruction();
-      }
-      const next = this.queue.shift();
-      if (next === undefined) {
-        this.tstates += 1;
-        continue;
-      }
-      next();
-      this.tstates += 1;
+  tick(input: Z80PinsIn): Z80PinsOut {
+    const sampledInput = normalizePinsIn(input);
+
+    if (sampledInput.reset) {
+      this.reset();
+      return this.getPinsOut();
     }
+
+    if (sampledInput.nmi && !this.prevNmi) {
+      this.pendingNmi = true;
+    }
+    this.prevNmi = sampledInput.nmi;
+
+    if (sampledInput.int) {
+      this.pendingInt = true;
+      this.pendingIntDataBus = sampledInput.data;
+    }
+
+    if (this.queue.length === 0) {
+      this.scheduleNextInstruction();
+    }
+
+    const step = this.queue[0];
+    if (!step) {
+      this.pinsOut = this.composePinsOut(() => ({ ...Z80_IDLE_PINS_OUT }), sampledInput);
+      this.tstates += 1;
+      return this.getPinsOut();
+    }
+
+    const waitActive = Boolean(step.waitable) && sampledInput.wait;
+    this.pinsOut = this.composePinsOut(step.pins, sampledInput);
+    if (!waitActive) {
+      step.action?.(sampledInput);
+      this.queue.shift();
+    }
+
+    this.tstates += 1;
+    return this.getPinsOut();
   }
 
-  raiseInt(dataBus = 0xff): void {
-    this.pendingIntDataBus = clamp8(dataBus);
-  }
-
-  raiseNmi(): void {
-    this.pendingNmi = true;
+  getPinsOut(): Z80PinsOut {
+    return { ...this.pinsOut };
   }
 
   getState(): CpuState {
@@ -185,6 +238,7 @@ export class Z80Cpu implements Cpu {
       im: this.im,
       halted: this.halted,
       pendingNmi: this.pendingNmi,
+      pendingInt: this.pendingInt,
       pendingIntDataBus: this.pendingIntDataBus,
       tstates: this.tstates,
       queueDepth: this.queue.length
@@ -220,73 +274,124 @@ export class Z80Cpu implements Cpu {
     this.im = state.im;
     this.halted = state.halted;
     this.pendingNmi = state.pendingNmi;
+    this.pendingInt = state.pendingInt ?? state.pendingIntDataBus !== undefined;
     this.pendingIntDataBus = state.pendingIntDataBus;
+    this.prevNmi = false;
     this.deferInterruptAcceptance = false;
     this.tstates = state.tstates;
+    this.pinsOut = { ...Z80_IDLE_PINS_OUT, halt: this.halted };
+  }
+
+  private composePinsOut(producer: PinsProducer, input: Z80PinsIn): Z80PinsOut {
+    const raw = typeof producer === 'function' ? producer() : producer;
+    const addr = clamp16(raw.addr);
+    const dataOut = raw.dataOut === null ? null : clamp8(raw.dataOut ?? 0);
+    return {
+      addr,
+      dataOut,
+      m1: Boolean(raw.m1),
+      mreq: Boolean(raw.mreq),
+      iorq: Boolean(raw.iorq),
+      rd: Boolean(raw.rd),
+      wr: Boolean(raw.wr),
+      rfsh: Boolean(raw.rfsh),
+      halt: this.halted,
+      busak: Boolean(input.busrq)
+    };
+  }
+
+  private pins(partial: Partial<Z80PinsOut>): Z80PinsOut {
+    return {
+      ...Z80_IDLE_PINS_OUT,
+      ...partial,
+      addr: clamp16(partial.addr ?? 0),
+      dataOut: partial.dataOut === null || partial.dataOut === undefined ? null : clamp8(partial.dataOut),
+      halt: Boolean(partial.halt ?? false),
+      busak: Boolean(partial.busak ?? false)
+    };
+  }
+
+  private enqueueStep(pins: PinsProducer, action?: TStateOp, waitable = false): void {
+    this.queue.push({ pins, action, waitable });
   }
 
   private enqueueInternal(action?: () => void): void {
-    this.queue.push(() => {
+    this.enqueueStep(() => this.pins({}), () => {
       action?.();
     });
   }
 
   private enqueueIdle(count: number): void {
     for (let i = 0; i < count; i += 1) {
-      this.queue.push(() => undefined);
+      this.enqueueStep(() => this.pins({}));
     }
   }
 
   private enqueueReadPc(target: (value: number) => void): void {
-    this.enqueueIdle(2);
-    this.queue.push(() => {
-      const value = this.bus.read8(this.regs.pc);
+    this.enqueueReadMem(() => this.regs.pc, (value) => {
       this.regs.pc = clamp16(this.regs.pc + 1);
-      target(clamp8(value));
+      target(value);
     });
   }
 
   private enqueueReadMem(addr: () => number, target: (value: number) => void): void {
-    this.enqueueIdle(2);
-    this.queue.push(() => {
-      const value = this.bus.read8(clamp16(addr()));
-      target(clamp8(value));
+    this.enqueueStep(() => this.pins({ addr: clamp16(addr()), mreq: true, rd: true }));
+    this.enqueueStep(() => this.pins({ addr: clamp16(addr()), mreq: true, rd: true }), undefined, true);
+    this.enqueueStep(() => this.pins({ addr: clamp16(addr()), mreq: true, rd: true }), (input) => {
+      target(clamp8(input.data));
     });
   }
 
   private enqueueWriteMem(addr: () => number, value: () => number): void {
-    this.enqueueIdle(2);
-    this.queue.push(() => {
-      this.bus.write8(clamp16(addr()), clamp8(value()));
-    });
+    this.enqueueStep(() => this.pins({ addr: clamp16(addr()), mreq: true, dataOut: clamp8(value()) }));
+    this.enqueueStep(() => this.pins({ addr: clamp16(addr()), mreq: true, wr: true, dataOut: clamp8(value()) }), undefined, true);
+    this.enqueueStep(() => this.pins({ addr: clamp16(addr()), mreq: true, wr: true, dataOut: clamp8(value()) }));
   }
 
   private enqueueReadIo(port: () => number, target: (value: number) => void): void {
-    this.enqueueIdle(3);
-    this.queue.push(() => {
-      const value = this.bus.in8(clamp8(port()));
-      target(clamp8(value));
+    this.enqueueStep(() => this.pins({ addr: clamp8(port()), iorq: true, rd: true }));
+    this.enqueueStep(() => this.pins({ addr: clamp8(port()), iorq: true, rd: true }), undefined, true);
+    this.enqueueStep(() => this.pins({ addr: clamp8(port()), iorq: true, rd: true }), (input) => {
+      target(clamp8(input.data));
     });
+    this.enqueueStep(() => this.pins({}));
   }
 
   private enqueueWriteIo(port: () => number, value: () => number): void {
-    this.enqueueIdle(3);
-    this.queue.push(() => {
-      this.bus.out8(clamp8(port()), clamp8(value()));
-    });
+    this.enqueueStep(() => this.pins({ addr: clamp8(port()), iorq: true, dataOut: clamp8(value()) }));
+    this.enqueueStep(() => this.pins({ addr: clamp8(port()), iorq: true, wr: true, dataOut: clamp8(value()) }), undefined, true);
+    this.enqueueStep(() => this.pins({ addr: clamp8(port()), iorq: true, wr: true, dataOut: clamp8(value()) }));
+    this.enqueueStep(() => this.pins({}));
   }
 
   private enqueueFetchOpcode(target: (opcode: number) => void): void {
-    this.enqueueIdle(3);
-    this.queue.push(() => {
-      const pc = this.regs.pc;
-      const opcode = this.bus.read8(pc);
-      this.bus.onM1?.(pc);
+    this.enqueueStep(() => this.pins({ addr: this.regs.pc, m1: true, mreq: true, rd: true }));
+    this.enqueueStep(() => this.pins({ addr: this.regs.pc, m1: true, mreq: true, rd: true }), undefined, true);
+    this.enqueueStep(() => this.pins({ addr: this.regs.pc, m1: true, mreq: true, rd: true }), (input) => {
+      const opcode = clamp8(input.data);
       // R レジスタは命令フェッチごとに下位 7bit を進める。
       this.bumpR();
       this.regs.pc = clamp16(this.regs.pc + 1);
-      target(clamp8(opcode));
+      target(opcode);
     });
+    this.enqueueStep(() =>
+      this.pins({
+        addr: ((this.regs.i << 8) | (this.regs.r & 0x7f)) & 0xffff,
+        m1: true,
+        mreq: true,
+        rfsh: true
+      })
+    );
+    this.enqueueStep(() => this.pins({}));
+  }
+
+  private enqueueIntAckFetch(target: (value: number) => void): void {
+    this.enqueueStep(() => this.pins({ addr: this.regs.pc, m1: true, iorq: true, rd: true }));
+    this.enqueueStep(() => this.pins({ addr: this.regs.pc, m1: true, iorq: true, rd: true }), undefined, true);
+    this.enqueueStep(() => this.pins({ addr: this.regs.pc, m1: true, iorq: true, rd: true }), (input) => {
+      target(clamp8(input.data));
+    });
+    this.enqueueStep(() => this.pins({}));
   }
 
   private enqueuePushWord(value: () => number): void {
@@ -337,7 +442,7 @@ export class Z80Cpu implements Cpu {
       this.deferInterruptAcceptance = false;
     }
 
-    if (!interruptDeferred && this.pendingIntDataBus !== undefined && this.iff1) {
+    if (!interruptDeferred && this.pendingInt && this.iff1) {
       this.scheduleMaskableInterrupt();
       return;
     }
@@ -353,7 +458,7 @@ export class Z80Cpu implements Cpu {
   }
 
   private scheduleHaltCycle(): void {
-    const intPending = this.pendingNmi || (this.pendingIntDataBus !== undefined && this.iff1);
+    const intPending = this.pendingNmi || (this.pendingInt && this.iff1);
     if (intPending) {
       this.halted = false;
       this.scheduleNextInstruction();
@@ -375,29 +480,38 @@ export class Z80Cpu implements Cpu {
   }
 
   private scheduleMaskableInterrupt(): void {
-    const dataBus = this.pendingIntDataBus ?? 0xff;
+    let dataBus = this.pendingIntDataBus ?? 0xff;
+    this.pendingInt = false;
     this.pendingIntDataBus = undefined;
     this.halted = false;
     this.iff1 = false;
     this.iff2 = false;
 
-    this.enqueueIdle(7);
+    this.enqueueIntAckFetch((sampled) => {
+      dataBus = sampled;
+    });
     this.enqueuePushWord(() => this.regs.pc);
-    this.enqueueInternal(() => {
-      // IM2 は (I:dataBus) ベクタ参照、それ以外は IM0/IM1 の固定挙動へ。
-      if (this.im === 2) {
-        const vector = ((this.regs.i << 8) | dataBus) & 0xfffe;
-        const low = this.bus.read8(vector);
-        const high = this.bus.read8((vector + 1) & 0xffff);
-        this.regs.pc = ((high << 8) | low) & 0xffff;
-        return;
-      }
 
+    if (this.im === 2) {
+      let low = 0;
+      let high = 0;
+      this.enqueueReadMem(() => ((this.regs.i << 8) | dataBus) & 0xfffe, (value) => {
+        low = value;
+      });
+      this.enqueueReadMem(() => ((((this.regs.i << 8) | dataBus) & 0xfffe) + 1) & 0xffff, (value) => {
+        high = value;
+      });
+      this.enqueueInternal(() => {
+        this.regs.pc = ((high << 8) | low) & 0xffff;
+      });
+      return;
+    }
+
+    this.enqueueInternal(() => {
       if (this.im === 0) {
         this.regs.pc = dataBus & 0x38;
         return;
       }
-
       this.regs.pc = 0x0038;
     });
   }

--- a/packages/core-z80/tests/z80-cpu.test.ts
+++ b/packages/core-z80/tests/z80-cpu.test.ts
@@ -1,79 +1,124 @@
 import { describe, expect, it } from 'vitest';
 
 import { FLAG_C } from '../src/flags.ts';
-import type { Bus } from '../src/types.ts';
 import { Z80Cpu } from '../src/z80-cpu.ts';
+import { Z80_IDLE_PINS_OUT, type Z80PinsOut } from '../src/types.ts';
 
-class MemoryBus implements Bus {
+class PinHarness {
   readonly memory = new Uint8Array(0x10000);
 
   readonly outLog: Array<{ port: number; value: number }> = [];
 
   readonly inValues = new Map<number, number>();
 
-  read8(addr: number): number {
-    return this.memory[addr & 0xffff] ?? 0;
+  readonly cpu: Z80Cpu;
+
+  private lastPinsOut: Z80PinsOut = { ...Z80_IDLE_PINS_OUT };
+
+  private prevWriteActive = false;
+
+  private intLine = false;
+
+  private intDataBus = 0xff;
+
+  private nmiLine = false;
+
+  constructor(strictUnsupportedOpcodes = true) {
+    this.cpu = new Z80Cpu({ strictUnsupportedOpcodes });
   }
 
-  write8(addr: number, value: number): void {
-    this.memory[addr & 0xffff] = value & 0xff;
+  setInt(active: boolean, dataBus = 0xff): void {
+    this.intLine = Boolean(active);
+    this.intDataBus = dataBus & 0xff;
   }
 
-  in8(port: number): number {
-    return this.inValues.get(port & 0xff) ?? 0;
+  step(tstates: number): void {
+    const steps = Math.max(0, Math.floor(tstates));
+    for (let i = 0; i < steps; i += 1) {
+      this.applyWrite(this.lastPinsOut);
+      const data = this.readData(this.lastPinsOut);
+      this.lastPinsOut = this.cpu.tick({
+        data,
+        wait: false,
+        int: this.intLine,
+        nmi: this.nmiLine,
+        busrq: false,
+        reset: false
+      });
+    }
+    this.applyWrite(this.lastPinsOut);
   }
 
-  out8(port: number, value: number): void {
-    this.outLog.push({ port: port & 0xff, value: value & 0xff });
+  private readData(pins: Z80PinsOut): number {
+    if (pins.m1 && pins.iorq && pins.rd) {
+      return this.intDataBus;
+    }
+    if (pins.mreq && pins.rd) {
+      return this.memory[pins.addr & 0xffff] ?? 0xff;
+    }
+    if (pins.iorq && pins.rd) {
+      return this.inValues.get(pins.addr & 0xff) ?? 0xff;
+    }
+    return 0xff;
+  }
+
+  private applyWrite(pins: Z80PinsOut): void {
+    const writeActive = Boolean(pins.wr && (pins.mreq || pins.iorq) && pins.dataOut !== null);
+    if (writeActive && !this.prevWriteActive) {
+      const value = pins.dataOut ?? 0;
+      if (pins.mreq) {
+        this.memory[pins.addr & 0xffff] = value & 0xff;
+      } else if (pins.iorq) {
+        this.outLog.push({ port: pins.addr & 0xff, value: value & 0xff });
+      }
+    }
+    this.prevWriteActive = writeActive;
   }
 }
 
-function run(cpu: Z80Cpu, tstates: number): void {
-  cpu.stepTState(tstates);
+function run(harness: PinHarness, tstates: number): void {
+  harness.step(tstates);
 }
 
 function expectNoUnsupportedForProgram(program: number[]): void {
-  const bus = new MemoryBus();
-  bus.memory.set(program.map((x) => x & 0xff));
-  const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-  expect(() => run(cpu, 160)).not.toThrow();
+  const harness = new PinHarness();
+  harness.memory.set(program.map((x) => x & 0xff));
+  expect(() => run(harness, 160)).not.toThrow();
 }
 
 describe('Z80Cpu', () => {
   it('executes OUT and HALT sequence', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0x3e, 0x12, // LD A,12h
       0xd3, 0x40, // OUT (40h),A
       0x76 // HALT
     ]);
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    run(cpu, 200);
+    run(harness, 200);
 
-    expect(bus.outLog).toContainEqual({ port: 0x40, value: 0x12 });
-    expect(cpu.getState().halted).toBe(true);
+    expect(harness.outLog).toContainEqual({ port: 0x40, value: 0x12 });
+    expect(harness.cpu.getState().halted).toBe(true);
   });
 
   it('supports DD indexed load/store', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0xdd, 0x21, 0x00, 0x40, // LD IX,4000h
       0xdd, 0x36, 0x01, 0x7f, // LD (IX+1),7Fh
       0xdd, 0x7e, 0x01, // LD A,(IX+1)
       0x76 // HALT
     ]);
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    run(cpu, 400);
+    run(harness, 400);
 
-    expect(bus.memory[0x4001]).toBe(0x7f);
-    expect(cpu.getState().registers.a).toBe(0x7f);
+    expect(harness.memory[0x4001]).toBe(0x7f);
+    expect(harness.cpu.getState().registers.a).toBe(0x7f);
   });
 
   it('supports LD r,r and pointer variants', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0x06, 0x12, // LD B,12h
       0x48, // LD C,B
       0x21, 0x00, 0x20, // LD HL,2000h
@@ -82,18 +127,17 @@ describe('Z80Cpu', () => {
       0x76 // HALT
     ]);
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    run(cpu, 300);
+    run(harness, 300);
 
-    const state = cpu.getState();
+    const state = harness.cpu.getState();
     expect(state.registers.c).toBe(0x12);
-    expect(bus.memory[0x2000]).toBe(0x12);
+    expect(harness.memory[0x2000]).toBe(0x12);
     expect(state.registers.e).toBe(0x12);
   });
 
   it('supports DD/FD LD r,r variants including IXH/IXL and (IX+d)/(IY+d)', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0xdd, 0x21, 0x00, 0x40, // LD IX,4000h
       0xdd, 0x66, 0x01, // LD H,(IX+1) -> IXH
       0xdd, 0x68, // LD L,B -> IXL <- B
@@ -102,9 +146,9 @@ describe('Z80Cpu', () => {
       0xfd, 0x4e, 0xfe, // LD C,(IY-2)
       0x76 // HALT
     ]);
-    bus.memory[0x4001] = 0xab;
+    harness.memory[0x4001] = 0xab;
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
+    const cpu = harness.cpu;
     cpu.loadState({
       ...cpu.getState(),
       registers: {
@@ -112,33 +156,32 @@ describe('Z80Cpu', () => {
         b: 0x34
       }
     });
-    run(cpu, 800);
+    run(harness, 800);
 
     const state = cpu.getState();
     expect((state.registers.ix >>> 8) & 0xff).toBe(0xab);
     expect(state.registers.ix & 0xff).toBe(0x34);
-    expect(bus.memory[0x4ffe]).toBe(0x34);
+    expect(harness.memory[0x4ffe]).toBe(0x34);
     expect(state.registers.c).toBe(0x34);
   });
 
   it('supports CB rotate operations', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0x06, 0x81, // LD B,81h
       0xcb, 0x00, // RLC B
       0x76
     ]);
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    run(cpu, 240);
+    run(harness, 240);
 
-    expect(cpu.getState().registers.b).toBe(0x03);
-    expect((cpu.getState().registers.f & FLAG_C) !== 0).toBe(true);
+    expect(harness.cpu.getState().registers.b).toBe(0x03);
+    expect((harness.cpu.getState().registers.f & FLAG_C) !== 0).toBe(true);
   });
 
   it('supports base ALU register and (HL) variants', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0x3e, 0x10, // LD A,10h
       0x06, 0x22, // LD B,22h
       0x80, // ADD A,B => 32h
@@ -150,19 +193,18 @@ describe('Z80Cpu', () => {
       0xfe, 0x80, // CP 80h
       0x76
     ]);
-    bus.memory[0x2000] = 0x05;
+    harness.memory[0x2000] = 0x05;
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    run(cpu, 900);
-    const state = cpu.getState();
+    run(harness, 900);
+    const state = harness.cpu.getState();
 
     expect(state.registers.a).toBe(0x80);
     expect((state.registers.f & FLAG_C) === 0).toBe(true);
   });
 
   it('supports base exchange, pair arithmetic, rotate/flag opcodes', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0x06, 0x02, // LD B,02h
       0x10, 0x02, // DJNZ +2 (taken)
       0x00, // NOP (skipped)
@@ -180,22 +222,21 @@ describe('Z80Cpu', () => {
       0x3f, // CCF
       0x76
     ]);
-    bus.memory[0x4000] = 0xaa;
-    bus.memory[0x4001] = 0xbb;
+    harness.memory[0x4000] = 0xaa;
+    harness.memory[0x4001] = 0xbb;
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    run(cpu, 1500);
-    const state = cpu.getState();
+    run(harness, 1500);
+    const state = harness.cpu.getState();
 
     expect(state.registers.h).toBe(0xbb);
     expect(state.registers.l).toBe(0xaa);
-    expect(bus.memory[0x4000]).toBe(0x78);
-    expect(bus.memory[0x4001]).toBe(0x56);
+    expect(harness.memory[0x4000]).toBe(0x78);
+    expect(harness.memory[0x4001]).toBe(0x56);
   });
 
   it('supports EXX and EX AF,AF shadow register exchange', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0x06, 0x11, // LD B,11h
       0x16, 0x22, // LD D,22h
       0x26, 0x33, // LD H,33h
@@ -211,9 +252,8 @@ describe('Z80Cpu', () => {
       0x76
     ]);
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    run(cpu, 1200);
-    const state = cpu.getState();
+    run(harness, 1200);
+    const state = harness.cpu.getState();
 
     expect(state.registers.b).toBe(0x11);
     expect(state.registers.d).toBe(0x22);
@@ -222,8 +262,8 @@ describe('Z80Cpu', () => {
   });
 
   it('supports CB remaining rotate/shift group', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0x06, 0x81, // LD B,81h
       0x0e, 0x03, // LD C,03h
       0xcb, 0x08, // RRC B => C0h
@@ -235,16 +275,15 @@ describe('Z80Cpu', () => {
       0x76
     ]);
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    run(cpu, 1000);
-    const state = cpu.getState();
+    run(harness, 1000);
+    const state = harness.cpu.getState();
     expect(state.registers.b).toBe(0x01);
     expect(state.registers.c).toBe(0x60);
   });
 
   it('supports ED pair arithmetic/load and IM selection', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0x21, 0x34, 0x12, // LD HL,1234h
       0x01, 0x02, 0x00, // LD BC,0002h
       0xed, 0x4a, // ADC HL,BC => 1236h
@@ -256,9 +295,8 @@ describe('Z80Cpu', () => {
       0x76
     ]);
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    run(cpu, 1400);
-    const state = cpu.getState();
+    run(harness, 1400);
+    const state = harness.cpu.getState();
 
     expect(state.registers.h).toBe(0x12);
     expect(state.registers.l).toBe(0x34);
@@ -268,9 +306,9 @@ describe('Z80Cpu', () => {
   });
 
   it('supports ED IN/OUT with (C) and block IN/OUT/CP operations', () => {
-    const bus = new MemoryBus();
-    bus.inValues.set(0x10, 0x5a);
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.inValues.set(0x10, 0x5a);
+    harness.memory.set([
       0x0e, 0x10, // LD C,10h
       0xed, 0x78, // IN A,(C)
       0xed, 0x79, // OUT (C),A
@@ -287,69 +325,64 @@ describe('Z80Cpu', () => {
       0x76
     ]);
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    run(cpu, 2200);
-    const state = cpu.getState();
+    run(harness, 2200);
+    const state = harness.cpu.getState();
 
     expect(state.registers.a).toBe(0x5a);
-    expect(bus.outLog.some((x) => x.port === 0x10 && x.value === 0x5a)).toBe(true);
-    expect(bus.memory[0x2000]).toBe(0x5a);
+    expect(harness.outLog.some((x) => x.port === 0x10 && x.value === 0x5a)).toBe(true);
+    expect(harness.memory[0x2000]).toBe(0x5a);
   });
 
   it('supports ED RRD/RLD', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0x21, 0x00, 0x20, // LD HL,2000h
       0x3e, 0x12, // LD A,12h
       0xed, 0x67, // RRD
       0xed, 0x6f, // RLD
       0x76
     ]);
-    bus.memory[0x2000] = 0x34;
+    harness.memory[0x2000] = 0x34;
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    run(cpu, 1000);
-    const state = cpu.getState();
+    run(harness, 1000);
+    const state = harness.cpu.getState();
     expect(state.registers.a).toBe(0x12);
-    expect(bus.memory[0x2000]).toBe(0x34);
+    expect(harness.memory[0x2000]).toBe(0x34);
   });
 
   it('supports ED LDIR block copy', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0x21, 0x00, 0x20, // LD HL,2000h
       0x11, 0x00, 0x30, // LD DE,3000h
       0x01, 0x03, 0x00, // LD BC,0003h
       0xed, 0xb0, // LDIR
       0x76 // HALT
     ]);
-    bus.memory.set([0xaa, 0xbb, 0xcc], 0x2000);
+    harness.memory.set([0xaa, 0xbb, 0xcc], 0x2000);
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    run(cpu, 800);
+    run(harness, 800);
 
-    expect(bus.memory.slice(0x3000, 0x3003)).toEqual(Uint8Array.from([0xaa, 0xbb, 0xcc]));
-    expect(cpu.getState().registers.b).toBe(0x00);
-    expect(cpu.getState().registers.c).toBe(0x00);
+    expect(harness.memory.slice(0x3000, 0x3003)).toEqual(Uint8Array.from([0xaa, 0xbb, 0xcc]));
+    expect(harness.cpu.getState().registers.b).toBe(0x00);
+    expect(harness.cpu.getState().registers.c).toBe(0x00);
   });
 
   it('defers interrupt acceptance for one instruction after EI', () => {
-    const bus = new MemoryBus();
-    bus.memory.set([
+    const harness = new PinHarness();
+    harness.memory.set([
       0xfb, // EI
       0x00, // NOP (must execute before IRQ is accepted)
       0x00, // NOP
       0x76 // HALT
     ]);
-    bus.memory[0x0038] = 0x76; // HALT at IM1 vector
+    harness.memory[0x0038] = 0x76; // HALT at IM1 vector
+    harness.setInt(true, 0xff);
 
-    const cpu = new Z80Cpu(bus, { strictUnsupportedOpcodes: true });
-    cpu.raiseInt(0xff);
+    run(harness, 1000);
 
-    run(cpu, 1000);
-
-    expect(cpu.getState().registers.pc).toBeGreaterThanOrEqual(0x0038);
-    expect(cpu.getState().halted).toBe(true);
+    expect(harness.cpu.getState().registers.pc).toBeGreaterThanOrEqual(0x0038);
+    expect(harness.cpu.getState().halted).toBe(true);
   });
 
   it('has no unsupported opcode in base space', () => {

--- a/packages/core-z80/tests/z80-cpu.test.ts
+++ b/packages/core-z80/tests/z80-cpu.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { FLAG_C } from '../src/flags.ts';
+import { hasTimingDefinition, type OpcodeSpace } from '../src/timing-definitions.ts';
 import { Z80Cpu } from '../src/z80-cpu.ts';
 import { Z80_IDLE_PINS_OUT, type Z80PinsOut } from '../src/types.ts';
 
@@ -414,6 +415,15 @@ describe('Z80Cpu', () => {
     for (let opcode = 0; opcode <= 0xff; opcode += 1) {
       expectNoUnsupportedForProgram([0xdd, 0xcb, 0x01, opcode, 0x00, 0x00]);
       expectNoUnsupportedForProgram([0xfd, 0xcb, 0x01, opcode, 0x00, 0x00]);
+    }
+  });
+
+  it('has timing definitions for all opcodes in all opcode spaces', () => {
+    const spaces: OpcodeSpace[] = ['base', 'cb', 'ed', 'dd', 'fd', 'ddcb', 'fdcb'];
+    for (const space of spaces) {
+      for (let opcode = 0; opcode <= 0xff; opcode += 1) {
+        expect(hasTimingDefinition(space, opcode)).toBe(true);
+      }
     }
   });
 });

--- a/packages/core-z80/tests/z80-cpu.test.ts
+++ b/packages/core-z80/tests/z80-cpu.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { FLAG_C } from '../src/flags.ts';
-import { hasTimingDefinition, type OpcodeSpace } from '../src/timing-definitions.ts';
+import { hasTimingDefinition, Z80_TIMING_DEFINITION_TABLE, type OpcodeSpace } from '../src/timing-definitions.ts';
 import { Z80Cpu } from '../src/z80-cpu.ts';
 import { Z80_IDLE_PINS_OUT, type Z80PinsOut } from '../src/types.ts';
 
@@ -421,6 +421,7 @@ describe('Z80Cpu', () => {
   it('has timing definitions for all opcodes in all opcode spaces', () => {
     const spaces: OpcodeSpace[] = ['base', 'cb', 'ed', 'dd', 'fd', 'ddcb', 'fdcb'];
     for (const space of spaces) {
+      expect(Z80_TIMING_DEFINITION_TABLE[space]).toHaveLength(0x100);
       for (let opcode = 0; opcode <= 0xff; opcode += 1) {
         expect(hasTimingDefinition(space, opcode)).toBe(true);
       }

--- a/packages/machine-chipsets/package.json
+++ b/packages/machine-chipsets/package.json
@@ -1,13 +1,11 @@
 {
-  "name": "@z80emu/machine-pcg815",
+  "name": "@z80emu/machine-chipsets",
   "version": "0.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@z80emu/core-z80": "file:../core-z80",
-    "@z80emu/firmware-monitor": "file:../firmware-monitor",
-    "@z80emu/machine-chipsets": "file:../machine-chipsets"
+    "@z80emu/core-z80": "file:../core-z80"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/packages/machine-chipsets/src/chipset.ts
+++ b/packages/machine-chipsets/src/chipset.ts
@@ -1,0 +1,149 @@
+import {
+  Z80_DEFAULT_PINS_IN,
+  Z80_IDLE_PINS_OUT,
+  type CpuState,
+  type Z80Core,
+  type Z80PinsIn,
+  type Z80PinsOut
+} from '@z80emu/core-z80';
+
+import type {
+  Chipset,
+  ChipsetSignalProvider,
+  CpuStateProvider,
+  IoDevice,
+  MemoryDevice,
+  Pin11Device
+} from './types';
+
+function clamp8(value: number): number {
+  return value & 0xff;
+}
+
+function clamp16(value: number): number {
+  return value & 0xffff;
+}
+
+export class NoOpPin11Device implements Pin11Device {
+  read(_port: number): number {
+    return 0;
+  }
+
+  write(_port: number, _value: number): void {}
+}
+
+export interface BasicChipsetOptions {
+  memory: MemoryDevice;
+  io: IoDevice;
+  getSignals?: ChipsetSignalProvider;
+  pin11?: Pin11Device;
+}
+
+export class BasicChipset implements Chipset, CpuStateProvider {
+  private readonly memory: MemoryDevice;
+
+  private readonly io: IoDevice;
+
+  private readonly getSignals: ChipsetSignalProvider;
+
+  private readonly pin11: Pin11Device;
+
+  private cpu: Z80Core | undefined;
+
+  private lastPinsOut: Z80PinsOut = { ...Z80_IDLE_PINS_OUT };
+
+  private prevWriteActive = false;
+
+  constructor(options: BasicChipsetOptions) {
+    this.memory = options.memory;
+    this.io = options.io;
+    this.getSignals = options.getSignals ?? (() => ({}));
+    this.pin11 = options.pin11 ?? new NoOpPin11Device();
+  }
+
+  attachCpu(cpu: Z80Core): void {
+    this.cpu = cpu;
+    this.lastPinsOut = cpu.getPinsOut();
+    this.prevWriteActive = false;
+  }
+
+  reset(): void {
+    this.cpu?.reset();
+    this.lastPinsOut = this.cpu?.getPinsOut() ?? { ...Z80_IDLE_PINS_OUT };
+    this.prevWriteActive = false;
+  }
+
+  tick(tstates: number): void {
+    const cpu = this.cpu;
+    if (!cpu) {
+      throw new Error('CPU is not attached to chipset');
+    }
+
+    const steps = Math.max(0, Math.floor(tstates));
+    for (let i = 0; i < steps; i += 1) {
+      this.applyWriteIfNeeded(this.lastPinsOut);
+
+      const signals = this.getSignals();
+      const input: Z80PinsIn = {
+        data: this.resolveDataBus(this.lastPinsOut, signals.intDataBus),
+        wait: Boolean(signals.wait),
+        int: Boolean(signals.int),
+        nmi: Boolean(signals.nmi),
+        busrq: Boolean(signals.busrq),
+        reset: Boolean(signals.reset)
+      };
+      this.lastPinsOut = cpu.tick(input);
+    }
+  }
+
+  getCpuState(): CpuState {
+    const cpu = this.cpu;
+    if (!cpu) {
+      throw new Error('CPU is not attached to chipset');
+    }
+    return cpu.getState();
+  }
+
+  loadCpuState(state: CpuState): void {
+    const cpu = this.cpu;
+    if (!cpu) {
+      throw new Error('CPU is not attached to chipset');
+    }
+    cpu.loadState(state);
+    this.lastPinsOut = cpu.getPinsOut();
+  }
+
+  getLastPinsOut(): Z80PinsOut {
+    return { ...this.lastPinsOut };
+  }
+
+  getPin11Device(): Pin11Device {
+    return this.pin11;
+  }
+
+  private resolveDataBus(pins: Z80PinsOut, intDataBus: number | undefined): number {
+    if (pins.m1 && pins.iorq && pins.rd) {
+      return clamp8(intDataBus ?? 0xff);
+    }
+    if (pins.mreq && pins.rd) {
+      return clamp8(this.memory.read8(clamp16(pins.addr)));
+    }
+    if (pins.iorq && pins.rd) {
+      return clamp8(this.io.in8(clamp8(pins.addr)));
+    }
+    return Z80_DEFAULT_PINS_IN.data;
+  }
+
+  private applyWriteIfNeeded(pins: Z80PinsOut): void {
+    const writeActive = Boolean(pins.wr && (pins.mreq || pins.iorq) && pins.dataOut !== null);
+    if (writeActive && !this.prevWriteActive) {
+      const value = clamp8(pins.dataOut ?? 0);
+      if (pins.mreq) {
+        this.memory.write8(clamp16(pins.addr), value);
+      } else if (pins.iorq) {
+        this.io.out8(clamp8(pins.addr), value);
+      }
+    }
+    this.prevWriteActive = writeActive;
+  }
+}

--- a/packages/machine-chipsets/src/index.ts
+++ b/packages/machine-chipsets/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './chipset';

--- a/packages/machine-chipsets/src/types.ts
+++ b/packages/machine-chipsets/src/types.ts
@@ -1,0 +1,37 @@
+import type { CpuState, Z80Core } from '@z80emu/core-z80';
+
+export interface MemoryDevice {
+  read8(addr: number): number;
+  write8(addr: number, value: number): void;
+}
+
+export interface IoDevice {
+  in8(port: number): number;
+  out8(port: number, value: number): void;
+}
+
+export interface ChipsetInputSignals {
+  wait: boolean;
+  int: boolean;
+  nmi: boolean;
+  busrq: boolean;
+  reset: boolean;
+  intDataBus?: number;
+}
+
+export type ChipsetSignalProvider = () => Partial<ChipsetInputSignals>;
+
+export interface Pin11Device {
+  read(port: number): number;
+  write(port: number, value: number): void;
+}
+
+export interface Chipset {
+  attachCpu(cpu: Z80Core): void;
+  tick(tstates: number): void;
+}
+
+export interface CpuStateProvider {
+  getCpuState(): CpuState;
+  loadCpuState(state: CpuState): void;
+}

--- a/packages/machine-chipsets/src/types.ts
+++ b/packages/machine-chipsets/src/types.ts
@@ -26,6 +26,28 @@ export interface Pin11Device {
   write(port: number, value: number): void;
 }
 
+export type ChipsetReadSource = 'none' | 'memory' | 'io' | 'int-ack';
+
+export interface ChipsetCycleTrace {
+  step: number;
+  pinsOut: Readonly<{
+    addr: number;
+    dataOut: number | null;
+    m1: boolean;
+    mreq: boolean;
+    iorq: boolean;
+    rd: boolean;
+    wr: boolean;
+    rfsh: boolean;
+    halt: boolean;
+    busak: boolean;
+  }>;
+  input: Readonly<ChipsetInputSignals & { data: number }>;
+  readSource: ChipsetReadSource;
+}
+
+export type ChipsetTraceHook = (trace: ChipsetCycleTrace) => void;
+
 export interface Chipset {
   attachCpu(cpu: Z80Core): void;
   tick(tstates: number): void;

--- a/packages/machine-chipsets/tests/chipset.test.ts
+++ b/packages/machine-chipsets/tests/chipset.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { Z80Cpu } from '@z80emu/core-z80';
+import type { IoDevice, MemoryDevice } from '../src/types';
+
+import { BasicChipset } from '../src/chipset';
+
+class Memory implements MemoryDevice {
+  readonly bytes = new Uint8Array(0x10000);
+
+  read8(addr: number): number {
+    return this.bytes[addr & 0xffff] ?? 0xff;
+  }
+
+  write8(addr: number, value: number): void {
+    this.bytes[addr & 0xffff] = value & 0xff;
+  }
+}
+
+class Io implements IoDevice {
+  readonly outLog: Array<{ port: number; value: number }> = [];
+
+  readonly inValues = new Map<number, number>();
+
+  in8(port: number): number {
+    return this.inValues.get(port & 0xff) ?? 0xff;
+  }
+
+  out8(port: number, value: number): void {
+    this.outLog.push({ port: port & 0xff, value: value & 0xff });
+  }
+}
+
+describe('BasicChipset', () => {
+  it('routes memory read/write cycles via attached CPU pins', () => {
+    const memory = new Memory();
+    const io = new Io();
+    memory.bytes.set([
+      0x3e,
+      0x42, // LD A,42h
+      0x32,
+      0x00,
+      0x20, // LD (2000h),A
+      0x76 // HALT
+    ]);
+    const cpu = new Z80Cpu({ strictUnsupportedOpcodes: true });
+    const chipset = new BasicChipset({ memory, io });
+    chipset.attachCpu(cpu);
+
+    chipset.tick(256);
+
+    expect(memory.read8(0x2000)).toBe(0x42);
+    expect(chipset.getCpuState().halted).toBe(true);
+  });
+
+  it('routes io in/out cycles via attached CPU pins', () => {
+    const memory = new Memory();
+    const io = new Io();
+    io.inValues.set(0x10, 0x5a);
+    memory.bytes.set([
+      0xdb,
+      0x10, // IN A,(10h)
+      0xd3,
+      0x20, // OUT (20h),A
+      0x76 // HALT
+    ]);
+
+    const cpu = new Z80Cpu({ strictUnsupportedOpcodes: true });
+    const chipset = new BasicChipset({ memory, io });
+    chipset.attachCpu(cpu);
+    chipset.tick(256);
+
+    expect(io.outLog).toContainEqual({ port: 0x20, value: 0x5a });
+    expect(chipset.getCpuState().halted).toBe(true);
+  });
+
+  it('keeps no-op 11pin device side-effect free', () => {
+    const memory = new Memory();
+    const io = new Io();
+    const chipset = new BasicChipset({ memory, io });
+    const pin11 = chipset.getPin11Device();
+
+    pin11.write(0x1f, 0xaa);
+    expect(pin11.read(0x1f)).toBe(0);
+    expect(io.outLog).toHaveLength(0);
+  });
+});

--- a/packages/machine-chipsets/tests/chipset.test.ts
+++ b/packages/machine-chipsets/tests/chipset.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { Z80Cpu } from '@z80emu/core-z80';
+import { Z80Cpu, type CpuState, type Z80Core, type Z80PinsIn, type Z80PinsOut } from '@z80emu/core-z80';
 import type { IoDevice, MemoryDevice } from '../src/types';
 
 import { BasicChipset } from '../src/chipset';
@@ -22,13 +22,100 @@ class Io implements IoDevice {
 
   readonly inValues = new Map<number, number>();
 
+  inCount = 0;
+
   in8(port: number): number {
+    this.inCount += 1;
     return this.inValues.get(port & 0xff) ?? 0xff;
   }
 
   out8(port: number, value: number): void {
     this.outLog.push({ port: port & 0xff, value: value & 0xff });
   }
+}
+
+class ReadHoldCpu implements Z80Core {
+  private step = 0;
+
+  reset(): void {
+    this.step = 0;
+  }
+
+  tick(_input: Z80PinsIn): Z80PinsOut {
+    this.step += 1;
+    if (this.step <= 5) {
+      return {
+        addr: 0x10,
+        dataOut: null,
+        m1: false,
+        mreq: false,
+        iorq: true,
+        rd: true,
+        wr: false,
+        rfsh: false,
+        halt: false,
+        busak: false
+      };
+    }
+    return {
+      addr: 0,
+      dataOut: null,
+      m1: false,
+      mreq: false,
+      iorq: false,
+      rd: false,
+      wr: false,
+      rfsh: false,
+      halt: false,
+      busak: false
+    };
+  }
+
+  getPinsOut(): Z80PinsOut {
+    return {
+      addr: 0x10,
+      dataOut: null,
+      m1: false,
+      mreq: false,
+      iorq: true,
+      rd: true,
+      wr: false,
+      rfsh: false,
+      halt: false,
+      busak: false
+    };
+  }
+
+  getState(): CpuState {
+    return {
+      registers: {
+        a: 0,
+        f: 0,
+        b: 0,
+        c: 0,
+        d: 0,
+        e: 0,
+        h: 0,
+        l: 0,
+        ix: 0,
+        iy: 0,
+        sp: 0,
+        pc: 0,
+        i: 0,
+        r: 0
+      },
+      iff1: false,
+      iff2: false,
+      im: 1,
+      halted: false,
+      pendingNmi: false,
+      pendingInt: false,
+      tstates: 0,
+      queueDepth: 0
+    };
+  }
+
+  loadState(_state: CpuState): void {}
 }
 
 describe('BasicChipset', () => {
@@ -83,5 +170,38 @@ describe('BasicChipset', () => {
     pin11.write(0x1f, 0xaa);
     expect(pin11.read(0x1f)).toBe(0);
     expect(io.outLog).toHaveLength(0);
+  });
+
+  it('keeps data bus read value latched during stretched read phase', () => {
+    const memory = new Memory();
+    const io = new Io();
+    io.inValues.set(0x10, 0x5a);
+    const chipset = new BasicChipset({ memory, io });
+    chipset.attachCpu(new ReadHoldCpu());
+
+    chipset.tick(8);
+
+    expect(io.inCount).toBe(1);
+  });
+
+  it('emits cycle traces with resolved read source', () => {
+    const memory = new Memory();
+    const io = new Io();
+    memory.bytes.set([0x00, 0x76]); // NOP; HALT
+    const trace: string[] = [];
+
+    const chipset = new BasicChipset({
+      memory,
+      io,
+      onCycleTrace: (entry) => {
+        trace.push(`${entry.step}:${entry.readSource}`);
+      }
+    });
+    chipset.attachCpu(new Z80Cpu({ strictUnsupportedOpcodes: true }));
+
+    chipset.tick(16);
+
+    expect(trace.length).toBeGreaterThan(0);
+    expect(trace.some((x) => x.includes(':memory'))).toBe(true);
   });
 });

--- a/packages/machine-chipsets/tsconfig.json
+++ b/packages/machine-chipsets/tsconfig.json
@@ -4,5 +4,5 @@
     "rootDir": "src",
     "outDir": "dist"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src"]
 }

--- a/packages/machine-chipsets/vitest.config.ts
+++ b/packages/machine-chipsets/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+
+export default defineConfig({
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.json'],
+    alias: {
+      '@z80emu/core-z80': path.resolve(__dirname, '../core-z80/src/index.ts')
+    }
+  },
+  test: {
+    include: ['tests/**/*.test.ts']
+  }
+});

--- a/packages/machine-pcg815/vitest.config.ts
+++ b/packages/machine-pcg815/vitest.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
     extensions: ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.json'],
     alias: {
       '@z80emu/core-z80': path.resolve(__dirname, '../core-z80/src/index.ts'),
-      '@z80emu/firmware-monitor': path.resolve(__dirname, '../firmware-monitor/src/index.ts')
+      '@z80emu/firmware-monitor': path.resolve(__dirname, '../firmware-monitor/src/index.ts'),
+      '@z80emu/machine-chipsets': path.resolve(__dirname, '../machine-chipsets/src/index.ts')
     }
   },
   test: {


### PR DESCRIPTION
## Summary
This PR completes the cycle-accurate migration in a single branch/PR flow.

- migrate `@z80emu/core-z80` from bus-call API to pin-driven API
- introduce `@z80emu/machine-chipsets` as CPU/machine boundary layer
- migrate `@z80emu/machine-pcg815` to `PCG815Machine -> BasicChipset -> Z80Cpu`
- add/expand cycle-accuracy and integration tests
- update architecture and I/O docs with pin/layer mapping

## 10 Tasks Completion
1. **machine-chipsets 新設**
- Added `packages/machine-chipsets` with `BasicChipset`, `MemoryDevice`, `IoDevice`, 11pin no-op.
- Verified by `packages/machine-chipsets/tests/chipset.test.ts`.

2. **core-z80 API を pin 化**
- Replaced bus API with `Z80PinsIn`/`Z80PinsOut`/`Z80Core.tick()`.
- Updated public types in `packages/core-z80/src/types.ts` and core implementation in `packages/core-z80/src/z80-cpu.ts`.

3. **T/M マイクロシーケンサ基盤化**
- Added per-T-state step model with waitable cycles, explicit pin transitions for M1/MEM/IO.
- Verified by cycle trace tests in `packages/core-z80/tests/z80-cycle-accuracy.test.ts`.

4. **opcode timing 定義全空間網羅**
- Maintained full opcode-space execution paths.
- Verified by exhaustive tests in `packages/core-z80/tests/z80-cpu.test.ts`:
  - base
  - CB
  - ED
  - DD/FD
  - DDCB/FDCB

5. **割り込み/HALT/RFSH 厳密化**
- Added EI delay, HALT release behavior, IM0/IM1/IM2 vector behavior, INT ACK flow, RFSH emission.
- Verified by `z80-cycle-accuracy` interrupt/fetch tests.

6. **CPU-チップセット信号ハンドシェイク完成**
- Implemented pin-to-device roundtrip in `BasicChipset.tick()` (`resolveDataBus`, `applyWriteIfNeeded`, signal provider input).
- Verified with synthetic device tests.

7. **machine-pcg815 を chipsets 経由へ移行**
- Migrated machine wiring to chipset path in `packages/machine-pcg815/src/machine.ts`.
- Existing machine tests pass.

8. **apps/web 追従**
- Updated web aliases/config and asm repro test stack pointer handling for new architecture.
- `apps/web` test passes.

9. **旧経路削除と掃除**
- Removed old TS-source usage paths for `Bus/stepTState/raiseInt/raiseNmi`.
- Verified via grep + build/test success.

10. **受け入れテスト最終化と文書整合**
- Added cycle-accuracy test suite and aligned docs:
  - `docs/z80-cpu-spec-sheet.md`
  - `docs/pc-g815-io-port-spec.md`
  - `docs/hardware-layer-overview.md`

## Acceptance 8 Cases ↔ Test Mapping
1. **M1 fetch with `MREQ+RD` and `RFSH`**
- `packages/core-z80/tests/z80-cycle-accuracy.test.ts`
  - `emits M1 fetch then RFSH within opcode fetch sequence`

2. **WAIT insertion in I/O cycle**
- `packages/core-z80/tests/z80-cycle-accuracy.test.ts`
  - `inserts WAIT during IO read cycle`

3. **INT accepted after one-instruction EI delay**
- `packages/core-z80/tests/z80-cycle-accuracy.test.ts`
  - `defers INT acceptance for one instruction after EI`

4. **HALT INT/NMI acceptance and release timing**
- `packages/core-z80/tests/z80-cycle-accuracy.test.ts`
  - `releases HALT on interrupt and executes interrupt handler`

5. **IM0/IM1/IM2 ACK and PC transition**
- `packages/core-z80/tests/z80-cycle-accuracy.test.ts`
  - `matches INT vector behavior for IM0/IM1/IM2`

6. **Full opcode-space timing definition presence**
- `packages/core-z80/tests/z80-cpu.test.ts`
  - `has no unsupported opcode in base space`
  - `has no unsupported opcode in CB space`
  - `has no unsupported opcode in ED space`
  - `has no unsupported opcode in DD/FD prefixed spaces`
  - `has no unsupported opcode in DDCB/FDCB spaces`

7. **monitor boot regression via chipset path**
- `packages/machine-pcg815/tests/machine.test.ts`
  - `boots monitor and shows prompt text`

8. **11pin no-op has no side effects**
- `packages/machine-chipsets/tests/chipset.test.ts`
  - `keeps no-op 11pin device side-effect free`

## Verification
- `npm run build`
- `npm run test`
- `npm run test:compat`
