### PR TITLE
refactor: route execution through firmware-oriented backend controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ npm run dev
 
 - タブは `BASIC` / `ASSEMBLER` の2つで、初期表示は `BASIC` です。
 
+### 実行バックエンド（併存運用）
+
+- 既定バックエンドは `z80-firmware` です（`PCG815MachineOptions.executionBackend`）。
+- `ts-compat` は保守用フォールバックとして残しています。
+- Web ではクエリで切替できます。
+  - `?backend=z80-firmware`（既定）
+  - `?backend=ts-compat`
+- 現行フェーズでは両系統を並行運用し、主経路は `z80-firmware` に寄せています。
+
 ### BASIC タブ
 
 - 右側の `BASIC Editor` にプログラムを入力し、`RUN Program` で実行します
@@ -26,6 +35,7 @@ npm run dev
 
 - `ASSEMBLE` で Z80 アセンブルを実行し、機械語ダンプを表示します
 - `RUN` は直近アセンブル結果を RAM にロードし、`ENTRY` から実行します
+- 実行完了判定は「プログラム領域外PC」ではなく「ファームウェア復帰点到達」です
 - `STOP CPU` は CPU 実行を停止します
 - `Load Sample` は非ゲームのサンプル（チェックサム計算）を読み込みます
 - 詳細仕様: `docs/assembly-language-spec.md`

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -216,7 +216,7 @@ test('basic load sample runs on fresh boot', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Load Sample' }).click();
   await page.getByRole('button', { name: 'RUN Program' }).click();
-  await expect(page.locator('#basic-run-status')).toContainText(/Run OK/i, { timeout: 5_000 });
+  await expect(page.locator('#basic-run-status')).toContainText(/Run OK/i, { timeout: 15_000 });
 
   await expect
     .poll(
@@ -225,7 +225,7 @@ test('basic load sample runs on fresh boot', async ({ page }) => {
           const api = window as { __pcg815?: { getTextLines: () => string[] } };
           return (api.__pcg815?.getTextLines() ?? []).join('\n');
         }),
-      { timeout: 5_000, intervals: [100, 250, 500] }
+      { timeout: 15_000, intervals: [100, 250, 500] }
     )
     .toContain('owari');
 });

--- a/packages/firmware-monitor/src/monitor-rom.ts
+++ b/packages/firmware-monitor/src/monitor-rom.ts
@@ -1,5 +1,6 @@
 // モニタ ROM は 16KiB 窓を前提に作成する。
 const ROM_SIZE = 0x4000;
+export const MONITOR_MAIN_LOOP_ADDR = 0x0011;
 
 function textToBytes(text: string): number[] {
   return [...text].map((ch) => ch.charCodeAt(0));

--- a/packages/machine-pcg815/src/types.ts
+++ b/packages/machine-pcg815/src/types.ts
@@ -1,6 +1,9 @@
 import type { CpuState } from '@z80emu/core-z80';
 import type { MonitorRuntimeSnapshot } from '@z80emu/firmware-monitor';
 
+export type PCG815ExecutionBackend = 'z80-firmware' | 'ts-compat';
+export type PCG815ExecutionDomain = 'firmware' | 'user-program';
+
 // 永続化用スナップショットの現行フォーマット。
 export interface SnapshotV1 {
   version: 1;
@@ -19,6 +22,9 @@ export interface SnapshotV1 {
     kanaComposeBuffer: string;
     romBankSelect: number;
     expansionControl: number;
+    executionDomain?: PCG815ExecutionDomain;
+    executionBackend?: PCG815ExecutionBackend;
+    firmwareReturnAddress?: number;
     runtime: MonitorRuntimeSnapshot;
   };
   timestampTStates: number;
@@ -30,6 +36,15 @@ export interface MachinePCG815 {
   setKeyState(code: string, pressed: boolean): void;
   setKanaMode(enabled: boolean): void;
   getKanaMode(): boolean;
+  getExecutionBackend(): PCG815ExecutionBackend;
+  getExecutionDomain(): PCG815ExecutionDomain;
+  setExecutionDomain(domain: PCG815ExecutionDomain): void;
+  getFirmwareReturnAddress(): number;
+  setFirmwareReturnAddress(address: number): void;
+  getActiveRomBank(): number;
+  getActiveExRomBank(): number;
+  getActiveRamBank(): number;
+  drainAsciiQueue(): number[];
   isRuntimeProgramRunning(): boolean;
   getFrameBuffer(): Uint8Array;
   reset(cold: boolean): void;
@@ -43,4 +58,6 @@ export interface MachinePCG815 {
 export interface PCG815MachineOptions {
   rom?: Uint8Array;
   strictCpuOpcodes?: boolean;
+  executionBackend?: PCG815ExecutionBackend;
+  firmwareReturnAddress?: number;
 }


### PR DESCRIPTION
## Summary
- add execution backend controls (`z80-firmware` default, `ts-compat` fallback)
- add execution domain/public state APIs and firmware return-address handling
- implement RAM/ROM bank-window switching behavior via ports `0x19` / `0x1B`
- replace ASM completion heuristic with firmware-return based completion flow
- update web runtime wiring and smoke timeout to keep WAIT real-time behavior

## Testing
- `npm test`
- `npm run test:e2e`
