### PR TITLE
fix: redesign machine monitor for persistent gaming-style diagnostics

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -39,6 +39,50 @@
               </button>
             </div>
           </div>
+          <section id="machine-monitor" class="machine-monitor">
+            <div class="monitor-head">
+              <h2>Machine Monitor</h2>
+              <span id="monitor-summary" class="monitor-summary">BOOTING</span>
+            </div>
+            <div class="monitor-grid">
+              <section class="monitor-card">
+                <h3>Main Registers</h3>
+                <div id="monitor-register-main" class="register-grid"></div>
+              </section>
+              <section class="monitor-card">
+                <h3>Shadow Registers</h3>
+                <div id="monitor-register-shadow" class="register-grid"></div>
+              </section>
+              <section class="monitor-card">
+                <h3>Address Bus</h3>
+                <div id="monitor-address-hex" class="bus-hex">0x0000</div>
+                <div id="monitor-address-bits" class="bit-grid"></div>
+              </section>
+              <section class="monitor-card">
+                <h3>Data Bus</h3>
+                <div id="monitor-data-hex" class="bus-hex">0x00</div>
+                <div id="monitor-data-bits" class="bit-grid"></div>
+              </section>
+              <section class="monitor-card monitor-card-wide">
+                <h3>CPU Pins (H/L)</h3>
+                <div id="monitor-pin-grid" class="pin-grid"></div>
+              </section>
+            </div>
+            <h3>Input Log</h3>
+            <pre id="log-view" class="log-view"></pre>
+          </section>
+          <h3>Key Matrix Map</h3>
+          <div id="keymap-list" class="keymap-list"></div>
+          <section id="font-debug-panel" class="font-debug-panel" hidden>
+            <div class="font-debug-head">
+              <h3>Font 5x7 Atlas</h3>
+              <span id="font-debug-meta" class="font-debug-meta">0x41 "A"</span>
+            </div>
+            <p class="font-debug-hint">Click a cell to inspect glyph code (0x00-0xFF).</p>
+            <canvas id="font-debug-canvas" aria-label="Font 5x7 glyph atlas"></canvas>
+            <h4 class="font-kana-title">A0-DF Zoom</h4>
+            <canvas id="font-kana-canvas" aria-label="Kana glyph zoom"></canvas>
+          </section>
         </section>
 
         <section class="status-panel">
@@ -349,23 +393,8 @@ SHIFT_TABLE:
             <pre id="asm-dump-view" class="debug-view asm-dump-view"></pre>
           </section>
 
-          <h2>Status</h2>
-          <pre id="debug-view" class="debug-view" hidden></pre>
-          <h3>Input Log</h3>
-          <pre id="log-view" class="log-view"></pre>
-          <h3>Key Matrix Map</h3>
-          <div id="keymap-list" class="keymap-list"></div>
-          <section id="font-debug-panel" class="font-debug-panel" hidden>
-            <div class="font-debug-head">
-              <h3>Font 5x7 Atlas</h3>
-              <span id="font-debug-meta" class="font-debug-meta">0x41 "A"</span>
-            </div>
-            <p class="font-debug-hint">Click a cell to inspect glyph code (0x00-0xFF).</p>
-            <canvas id="font-debug-canvas" aria-label="Font 5x7 glyph atlas"></canvas>
-            <h4 class="font-kana-title">A0-DF Zoom</h4>
-            <canvas id="font-kana-canvas" aria-label="Kana glyph zoom"></canvas>
-          </section>
         </section>
+
       </main>
     </div>
 

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -67,6 +67,8 @@ declare global {
       getCompatRouteStats: () => CompatRouteStats;
       getFirmwareRouteStats: () => FirmwareRouteStats & ReturnType<PCG815Machine['getFirmwareIoStats']>;
       getBasicEngineStatus: () => ReturnType<PCG815Machine['getBasicEngineStatus']>;
+      getCpuPinsOut: () => ReturnType<PCG815Machine['getCpuPinsOut']>;
+      getCpuPinsIn: () => ReturnType<PCG815Machine['getCpuPinsIn']>;
       tapKey: (code: string) => void;
       assembleAsm: (source: string) => { ok: boolean; errorLine?: string; dump: string };
       runAsm: (source: string) => Promise<RunAsmProgramResult>;
@@ -77,7 +79,6 @@ declare global {
 
 const SCALE = 4;
 const query = new URLSearchParams(window.location.search);
-const debugMode = query.get('debug') === '1';
 const strictMode = query.get('strict') === '1';
 const executionBackend = query.get('backend') === 'ts-compat' ? 'ts-compat' : 'z80-firmware';
 const FIRMWARE_LINE_END = 0x0d;
@@ -111,7 +112,14 @@ const kanaToggleButton = mustQuery<HTMLButtonElement>('#kana-toggle');
 const fontDebugToggleButton = mustQuery<HTMLButtonElement>('#font-debug-toggle');
 const speedIndicator = mustQuery<HTMLElement>('#speed-indicator');
 const bootStatus = mustQuery<HTMLElement>('#boot-status');
-const debugView = mustQuery<HTMLElement>('#debug-view');
+const monitorSummary = mustQuery<HTMLElement>('#monitor-summary');
+const monitorRegisterMain = mustQuery<HTMLElement>('#monitor-register-main');
+const monitorRegisterShadow = mustQuery<HTMLElement>('#monitor-register-shadow');
+const monitorAddressHex = mustQuery<HTMLElement>('#monitor-address-hex');
+const monitorAddressBits = mustQuery<HTMLElement>('#monitor-address-bits');
+const monitorDataHex = mustQuery<HTMLElement>('#monitor-data-hex');
+const monitorDataBits = mustQuery<HTMLElement>('#monitor-data-bits');
+const monitorPinGrid = mustQuery<HTMLElement>('#monitor-pin-grid');
 const logView = mustQuery<HTMLElement>('#log-view');
 const keyMapList = mustQuery<HTMLElement>('#keymap-list');
 const editorTabBasic = mustQuery<HTMLButtonElement>('#editor-tab-basic');
@@ -763,6 +771,7 @@ let asmRunInFlight = false;
 let asmRunToken = 0;
 let asmBuildCache: AsmBuildCache | undefined;
 let currentEditorMode: EditorMode = 'basic';
+let lastMonitorRenderMs = 0;
 const compatRouteStats: CompatRouteStats = {
   executeLineCalls: 0,
   runProgramCalls: 0,
@@ -781,10 +790,6 @@ function waitForAnimationFrame(): Promise<void> {
   return new Promise((resolve) => {
     requestAnimationFrame(() => resolve());
   });
-}
-
-if (debugMode) {
-  debugView.hidden = false;
 }
 
 keyMapList.innerHTML = KEY_MAP.slice(0, 32)
@@ -1118,6 +1123,14 @@ async function runBasicProgram(
     // Z80ファーム経路は frame ループ側で継続実行し、
     // 復帰判定も frame 側で行う。
     if (machine.getExecutionBackend() === 'z80-firmware') {
+      // 短いプログラムは同一フレーム内で user-program -> firmware へ戻ることがあり、
+      // frame 側が遷移を観測できない場合があるためここで即時完了を判定する。
+      if (z80RunAwaitingCompletion && machine.getExecutionDomain() !== 'user-program') {
+        clearZ80RunTracking();
+        setProgramRunStatus('ok', 'Run OK');
+        appendLog('BASIC RUN ok');
+        return { ok: true };
+      }
       setProgramRunStatus('running', 'Running');
       appendLog('BASIC RUN running');
       return { ok: true };
@@ -1488,7 +1501,7 @@ function setFontDebugVisible(next: boolean): void {
 
 function getCpuSummary(): string {
   const state = machine.getCpuState();
-  const pc = `0x${state.registers.pc.toString(16).padStart(4, '0')}`;
+  const pc = `0x${state.registers.pc.toString(16).padStart(4, '0').toUpperCase()}`;
   return `pc=${pc} t=${state.tstates}`;
 }
 
@@ -1528,39 +1541,151 @@ function renderLcd(): number {
   return litPixels;
 }
 
-function updateDebugView(): void {
-  if (!debugMode && currentState === 'READY') {
+function toHex8(value: number): string {
+  return `0x${(value & 0xff).toString(16).padStart(2, '0').toUpperCase()}`;
+}
+
+function toHex16(value: number): string {
+  return `0x${(value & 0xffff).toString(16).padStart(4, '0').toUpperCase()}`;
+}
+
+function formatCompactTicks(value: number): string {
+  if (!Number.isFinite(value)) {
+    return 'N/A';
+  }
+  return new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 2
+  }).format(value);
+}
+
+function formatFullTicks(value: number): string {
+  if (!Number.isFinite(value)) {
+    return 'N/A';
+  }
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function renderRegisterGrid(
+  target: HTMLElement,
+  items: ReadonlyArray<{
+    name: string;
+    value: string;
+    title?: string;
+  }>
+): void {
+  target.innerHTML = items
+    .map(
+      (item) =>
+        `<div class="register-item"><span class="register-name">${item.name}</span><span class="register-value"${
+          item.title ? ` title="${item.title}"` : ''
+        }>${item.value}</span></div>`
+    )
+    .join('');
+}
+
+function renderBitGrid(target: HTMLElement, value: number, width: 8 | 16, prefix: 'A' | 'D'): void {
+  const labels: string[] = [];
+  for (let bit = width - 1; bit >= 0; bit -= 1) {
+    const on = ((value >> bit) & 0x01) !== 0;
+    labels.push(
+      `<span class="bit-chip" data-on="${on ? '1' : '0'}" title="${prefix}${bit}:${on ? '1' : '0'}">${prefix}${bit}</span>`
+    );
+  }
+  target.innerHTML = labels.join('');
+}
+
+function renderPinGrid(target: HTMLElement, items: ReadonlyArray<{ name: string; high: boolean }>): void {
+  target.innerHTML = items
+    .map(
+      (item) =>
+        `<div class="pin-item"><span class="pin-name">${item.name}</span><span class="pin-state" data-high="${item.high ? '1' : '0'}">${item.high ? 'H' : 'L'}</span></div>`
+    )
+    .join('');
+}
+
+function updateDebugView(nowMs?: number): void {
+  if (nowMs !== undefined && nowMs - lastMonitorRenderMs < 500) {
     return;
   }
+  lastMonitorRenderMs = nowMs ?? performance.now();
 
   const state = machine.getCpuState();
-  debugView.hidden = false;
-  debugView.textContent = JSON.stringify(
-    {
-      bootState: currentState,
-      strict: strictMode,
-      pc: `0x${state.registers.pc.toString(16).padStart(4, '0')}`,
-      sp: `0x${state.registers.sp.toString(16).padStart(4, '0')}`,
-      a: `0x${state.registers.a.toString(16).padStart(2, '0')}`,
-      f: `0x${state.registers.f.toString(16).padStart(2, '0')}`,
-      tstates: state.tstates,
-      halted: state.halted,
-      queueDepth: state.queueDepth,
-      kanaMode: machine.getKanaMode(),
-      executionBackend: machine.getExecutionBackend(),
-      executionDomain: machine.getExecutionDomain(),
-      activeRomBank: machine.getActiveRomBank(),
-      activeExRomBank: machine.getActiveExRomBank(),
-      activeRamBank: machine.getActiveRamBank(),
-      firmwareRouteStats: {
-        ...firmwareRouteStats,
-        ...machine.getFirmwareIoStats()
-      },
-      speed: speedIndicator.textContent
-    },
-    null,
-    2
-  );
+  const pinsOut = machine.getCpuPinsOut();
+  const pinsIn = machine.getCpuPinsIn();
+  const regs = state.registers;
+  const shadow = state.shadowRegisters;
+  const af = ((regs.a & 0xff) << 8) | (regs.f & 0xff);
+  const bc = ((regs.b & 0xff) << 8) | (regs.c & 0xff);
+  const de = ((regs.d & 0xff) << 8) | (regs.e & 0xff);
+  const hl = ((regs.h & 0xff) << 8) | (regs.l & 0xff);
+
+  renderRegisterGrid(monitorRegisterMain, [
+    { name: 'AF', value: toHex16(af) },
+    { name: 'BC', value: toHex16(bc) },
+    { name: 'DE', value: toHex16(de) },
+    { name: 'HL', value: toHex16(hl) },
+    { name: 'IX', value: toHex16(regs.ix) },
+    { name: 'IY', value: toHex16(regs.iy) },
+    { name: 'SP', value: toHex16(regs.sp) },
+    { name: 'PC', value: toHex16(regs.pc) },
+    { name: 'I', value: toHex8(regs.i) },
+    { name: 'R', value: toHex8(regs.r) },
+    { name: 'IFF1', value: state.iff1 ? '1' : '0' },
+    { name: 'IFF2', value: state.iff2 ? '1' : '0' },
+    { name: 'IM', value: `${state.im}` },
+    { name: 'HALT', value: state.halted ? '1' : '0' },
+    { name: 'T', value: formatCompactTicks(state.tstates), title: formatFullTicks(state.tstates) },
+    { name: 'Q', value: `${state.queueDepth}` }
+  ]);
+
+  if (shadow) {
+    const afp = ((shadow.a & 0xff) << 8) | (shadow.f & 0xff);
+    const bcp = ((shadow.b & 0xff) << 8) | (shadow.c & 0xff);
+    const dep = ((shadow.d & 0xff) << 8) | (shadow.e & 0xff);
+    const hlp = ((shadow.h & 0xff) << 8) | (shadow.l & 0xff);
+    renderRegisterGrid(monitorRegisterShadow, [
+      { name: "AF'", value: toHex16(afp) },
+      { name: "BC'", value: toHex16(bcp) },
+      { name: "DE'", value: toHex16(dep) },
+      { name: "HL'", value: toHex16(hlp) }
+    ]);
+  } else {
+    renderRegisterGrid(monitorRegisterShadow, [
+      { name: "AF'", value: 'N/A' },
+      { name: "BC'", value: 'N/A' },
+      { name: "DE'", value: 'N/A' },
+      { name: "HL'", value: 'N/A' }
+    ]);
+  }
+
+  const addressBus = pinsOut.addr & 0xffff;
+  const isWriteCycle = Boolean(pinsOut.wr && (pinsOut.mreq || pinsOut.iorq) && pinsOut.dataOut !== null);
+  const dataBus = isWriteCycle ? pinsOut.dataOut ?? 0xff : pinsIn.data;
+  monitorAddressHex.textContent = toHex16(addressBus);
+  monitorDataHex.textContent = toHex8(dataBus);
+  renderBitGrid(monitorAddressBits, addressBus, 16, 'A');
+  renderBitGrid(monitorDataBits, dataBus, 8, 'D');
+
+  renderPinGrid(monitorPinGrid, [
+    { name: 'M1', high: pinsOut.m1 },
+    { name: 'MREQ*', high: pinsOut.mreq },
+    { name: 'IORQ*', high: pinsOut.iorq },
+    { name: 'RD*', high: pinsOut.rd },
+    { name: 'WR*', high: pinsOut.wr },
+    { name: 'RFSH*', high: pinsOut.rfsh },
+    { name: 'HALT', high: pinsOut.halt },
+    { name: 'BUSAK', high: pinsOut.busak },
+    { name: 'WAIT', high: pinsIn.wait },
+    { name: 'INT', high: pinsIn.int },
+    { name: 'NMI', high: pinsIn.nmi },
+    { name: 'BUSRQ', high: pinsIn.busrq },
+    { name: 'RESET', high: pinsIn.reset }
+  ]);
+
+  monitorSummary.textContent = `${currentState} ${toHex16(regs.pc)} ${toHex8(dataBus)} ${
+    isWriteCycle ? 'WRITE' : 'READ'
+  } ${speedIndicator.textContent ?? '0.00x'}`;
 }
 
 function fail(state: 'FAILED' | 'STALLED', message: string, error?: unknown): void {
@@ -1571,22 +1696,7 @@ function fail(state: 'FAILED' | 'STALLED', message: string, error?: unknown): vo
   setBootStatus(state, `${reason} (${getCpuSummary()})`);
   appendLog(`${state} ${reason}`);
 
-  debugView.hidden = false;
-  const cpu = machine.getCpuState();
-  debugView.textContent = JSON.stringify(
-    {
-      state,
-      message,
-      reason,
-      pc: `0x${cpu.registers.pc.toString(16).padStart(4, '0')}`,
-      tstates: cpu.tstates,
-      queueDepth: cpu.queueDepth,
-      kanaMode: machine.getKanaMode(),
-      strict: strictMode
-    },
-    null,
-    2
-  );
+  updateDebugView();
 }
 
 function resetSpeedWindow(): void {
@@ -1631,7 +1741,7 @@ function boot(coldReset: boolean): boolean {
   } catch (error) {
     fail('FAILED', 'Boot exception', error);
     renderLcd();
-    updateDebugView();
+    updateDebugView(now);
     return false;
   }
 }
@@ -2063,6 +2173,8 @@ window.__pcg815 = {
     ...machine.getFirmwareIoStats()
   }),
   getBasicEngineStatus: () => machine.getBasicEngineStatus(),
+  getCpuPinsOut: () => machine.getCpuPinsOut(),
+  getCpuPinsIn: () => machine.getCpuPinsIn(),
   tapKey: (code: string) => {
     const pressTicks = 220_000;
     const releaseTicks = 260_000;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -54,8 +54,9 @@ body {
 
 .panel-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
   gap: 1rem;
+  align-items: start;
 }
 
 .device-panel,
@@ -70,6 +71,9 @@ body {
 
 .device-panel {
   padding: 1rem;
+  display: grid;
+  gap: 0.6rem;
+  align-content: start;
 }
 
 .device-body {
@@ -346,6 +350,226 @@ button[data-active='1'] {
   white-space: pre-wrap;
 }
 
+.machine-monitor {
+  margin: 0;
+  padding: 0.78rem;
+  border-radius: 10px;
+  border: 1px solid #00e5ff;
+  background:
+    linear-gradient(135deg, rgba(12, 9, 36, 0.94), rgba(8, 18, 48, 0.96)),
+    radial-gradient(700px 280px at 80% -20%, rgba(0, 255, 245, 0.24), transparent 60%),
+    radial-gradient(650px 240px at -10% 120%, rgba(255, 20, 147, 0.24), transparent 58%);
+  display: grid;
+  gap: 0.62rem;
+  box-shadow:
+    inset 0 0 0 1px rgba(107, 255, 249, 0.25),
+    0 0 28px rgba(0, 229, 255, 0.38),
+    0 12px 30px -18px rgba(0, 0, 0, 0.82);
+}
+
+.machine-monitor::before {
+  content: '';
+  position: absolute;
+  pointer-events: none;
+}
+
+.machine-monitor h2 {
+  font-size: 1rem;
+  color: #f4fcff;
+  text-shadow: 0 0 14px rgba(80, 248, 255, 0.92);
+}
+
+.monitor-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.monitor-summary {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.76rem;
+  border-radius: 999px;
+  border: 1px solid #00f0ff;
+  background: rgba(8, 18, 44, 0.88);
+  color: #ccfbff;
+  padding: 0.14rem 0.56rem;
+  box-shadow:
+    inset 0 0 0 1px rgba(173, 245, 255, 0.2),
+    0 0 10px rgba(0, 240, 255, 0.42);
+}
+
+.monitor-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  align-items: start;
+}
+
+.monitor-card {
+  border-radius: 8px;
+  border: 1px solid rgba(77, 243, 255, 0.88);
+  background:
+    linear-gradient(180deg, rgba(10, 20, 54, 0.9), rgba(6, 14, 35, 0.92)),
+    repeating-linear-gradient(
+      180deg,
+      rgba(124, 236, 255, 0.12) 0,
+      rgba(124, 236, 255, 0.12) 1px,
+      transparent 1px,
+      transparent 4px
+    );
+  padding: 0.52rem 0.56rem;
+  display: grid;
+  gap: 0.4rem;
+  box-shadow:
+    inset 0 0 0 1px rgba(130, 235, 255, 0.16),
+    0 0 20px rgba(0, 231, 255, 0.24);
+}
+
+.monitor-card h3 {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.2;
+  color: #d8fbff;
+  letter-spacing: 0.02em;
+  text-shadow: 0 0 10px rgba(76, 232, 255, 0.7);
+}
+
+.monitor-card-wide {
+  grid-column: 1 / -1;
+}
+
+.register-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.34rem 0.45rem;
+  align-content: start;
+}
+
+.register-item {
+  display: grid;
+  gap: 0.08rem;
+}
+
+.register-name {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.66rem;
+  color: #74d7ff;
+  text-transform: uppercase;
+}
+
+.register-value {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.9rem;
+  line-height: 1.15;
+  color: #f8fdff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-variant-numeric: tabular-nums;
+  text-shadow: 0 0 10px rgba(76, 237, 255, 0.58);
+}
+
+.bus-hex {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.98rem;
+  line-height: 1.25;
+  color: #f5feff;
+  background: linear-gradient(180deg, rgba(8, 48, 86, 0.96), rgba(6, 26, 56, 0.98));
+  border: 1px solid #41f3ff;
+  border-radius: 6px;
+  padding: 0.32rem 0.64rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.1rem;
+  min-width: 7.2ch;
+  width: fit-content;
+  white-space: nowrap;
+  overflow: visible;
+  box-shadow:
+    inset 0 0 0 1px rgba(141, 241, 255, 0.24),
+    0 0 18px rgba(26, 231, 255, 0.5);
+}
+
+.bit-grid {
+  display: grid;
+  grid-template-columns: repeat(8, minmax(0, 1fr));
+  gap: 0.24rem;
+}
+
+.bit-chip {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  line-height: 1.2;
+  text-align: center;
+  border-radius: 4px;
+  border: 1px solid #4d9cff;
+  background: rgba(9, 30, 64, 0.88);
+  color: #c4e3ff;
+  padding: 0.16rem 0.1rem;
+}
+
+.bit-chip[data-on='1'] {
+  border-color: #39ffea;
+  background: linear-gradient(180deg, rgba(9, 111, 124, 0.96), rgba(8, 67, 98, 0.98));
+  color: #f2fffd;
+  box-shadow: 0 0 12px rgba(52, 255, 230, 0.55);
+}
+
+.pin-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.3rem 0.35rem;
+}
+
+.pin-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem;
+  border: 1px solid #4e95de;
+  border-radius: 6px;
+  padding: 0.2rem 0.3rem;
+  background: rgba(8, 28, 60, 0.88);
+}
+
+.pin-name {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  color: #9dd9ff;
+}
+
+.pin-state {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.03rem 0.45rem;
+  border: 1px solid #6faee7;
+  color: #cfe8ff;
+  background: rgba(18, 45, 84, 0.94);
+}
+
+.pin-state[data-high='1'] {
+  border-color: #30ffe8;
+  color: #edfffd;
+  background: linear-gradient(180deg, rgba(7, 132, 136, 0.95), rgba(8, 78, 102, 0.98));
+  box-shadow: 0 0 12px rgba(62, 255, 220, 0.58);
+}
+
+.machine-monitor .log-view {
+  border-color: #45b7ff;
+  background: rgba(8, 24, 52, 0.9);
+  color: #e8f6ff;
+}
+
+.machine-monitor .keymap-list {
+  border-color: #45b7ff;
+  background: rgba(8, 24, 52, 0.9);
+  color: #e8f6ff;
+}
+
 .keymap-list {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
@@ -433,5 +657,18 @@ button[data-active='1'] {
   .hero {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .monitor-grid,
+  .pin-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .register-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .bit-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }

--- a/apps/web/tests/smoke.spec.ts
+++ b/apps/web/tests/smoke.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 test('app boots and renders lit LCD pixels without runtime errors', async ({ page }) => {
+  test.setTimeout(120_000);
   const pageErrors: string[] = [];
   const consoleErrors: string[] = [];
 
@@ -127,7 +128,7 @@ test('app boots and renders lit LCD pixels without runtime errors', async ({ pag
 
   await page.locator('#font-debug-canvas').click({ position: { x: 6, y: 6 } });
   await expect(page.locator('#font-debug-meta')).toContainText(/0x00/i);
-  await page.locator('#font-kana-canvas').click({ position: { x: 30, y: 8 } });
+  await page.locator('#font-kana-canvas').click({ position: { x: 64, y: 8 } });
   await expect(page.locator('#font-debug-meta')).toContainText(/0xA1/i);
 
   await expect
@@ -589,6 +590,46 @@ test('strict URL parameter enables strict boot mode diagnostics', async ({ page 
   await page.goto('/?strict=1&debug=1');
   await expect(page.locator('#boot-status')).toContainText(/READY/i, { timeout: 5_000 });
   await expect(page.locator('#boot-status')).toContainText(/strict=1/i);
+});
+
+test('machine monitor renders shadow registers and pin/bus visualization without debug flag', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#boot-status')).toContainText(/READY/i, { timeout: 5_000 });
+  await expect(page.locator('#machine-monitor')).toBeVisible();
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const lcd = document.querySelector('#lcd') as HTMLCanvasElement | null;
+          const monitor = document.querySelector('#machine-monitor') as HTMLElement | null;
+          if (!lcd || !monitor) {
+            return false;
+          }
+          const lcdRect = lcd.getBoundingClientRect();
+          const monitorRect = monitor.getBoundingClientRect();
+          return monitorRect.top >= lcdRect.bottom;
+        }),
+      { timeout: 2_000, intervals: [100, 250] }
+    )
+    .toBe(true);
+  await expect(page.locator('#machine-monitor')).toContainText(/Machine Monitor/i);
+  await expect(page.locator('#machine-monitor')).toContainText(/Shadow Registers/i);
+  await expect(page.locator('#monitor-register-shadow')).toContainText(/AF'/i);
+  await expect(page.locator('#monitor-register-shadow')).toContainText(/(N\/A|0x[0-9A-F]{4})/);
+  await expect(page.locator('#monitor-address-hex')).toContainText(/^0x[0-9A-F]{4}$/);
+  await expect(page.locator('#monitor-data-hex')).toContainText(/^0x[0-9A-F]{2}$/);
+  await expect(page.locator('#monitor-pin-grid')).toContainText(/MREQ/i);
+  await expect(page.locator('#log-view')).toBeVisible();
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const log = document.querySelector('#log-view');
+          return log?.closest('#machine-monitor')?.id ?? '';
+        }),
+      { timeout: 2_000, intervals: [100, 250] }
+    )
+    .toBe('machine-monitor');
 });
 
 test('accepts keyboard input on boot prompt without editor focus', async ({ page }) => {

--- a/packages/machine-chipsets/src/chipset.ts
+++ b/packages/machine-chipsets/src/chipset.ts
@@ -77,6 +77,8 @@ export class BasicChipset implements Chipset, CpuStateProvider {
     reset: false
   };
 
+  private lastIntDataBus = 0xff;
+
   private stepCounter = 0;
 
   constructor(options: BasicChipsetOptions) {
@@ -95,6 +97,7 @@ export class BasicChipset implements Chipset, CpuStateProvider {
     this.readLatch = Z80_DEFAULT_PINS_IN.data;
     this.prevReadSource = 'none';
     this.prevReadAddr = 0;
+    this.lastIntDataBus = 0xff;
     this.stepCounter = 0;
   }
 
@@ -106,6 +109,7 @@ export class BasicChipset implements Chipset, CpuStateProvider {
     this.readLatch = Z80_DEFAULT_PINS_IN.data;
     this.prevReadSource = 'none';
     this.prevReadAddr = 0;
+    this.lastIntDataBus = 0xff;
     this.stepCounter = 0;
   }
 
@@ -136,6 +140,7 @@ export class BasicChipset implements Chipset, CpuStateProvider {
       this.tickInput.nmi = Boolean(signals.nmi);
       this.tickInput.busrq = Boolean(signals.busrq);
       this.tickInput.reset = Boolean(signals.reset);
+      this.lastIntDataBus = clamp8(signals.intDataBus ?? 0xff);
 
       if (this.onCycleTrace) {
         this.emitTrace({
@@ -187,6 +192,14 @@ export class BasicChipset implements Chipset, CpuStateProvider {
 
   getLastPinsOut(): Z80PinsOut {
     return { ...this.lastPinsOut };
+  }
+
+  getLastPinsIn(): Z80PinsIn {
+    return { ...this.tickInput };
+  }
+
+  getLastIntDataBus(): number {
+    return this.lastIntDataBus & 0xff;
   }
 
   getPin11Device(): Pin11Device {

--- a/packages/machine-chipsets/src/types.ts
+++ b/packages/machine-chipsets/src/types.ts
@@ -1,4 +1,4 @@
-import type { CpuState, Z80Core } from '@z80emu/core-z80';
+import type { CpuState, Z80Core, Z80PinsIn, Z80PinsOut } from '@z80emu/core-z80';
 
 export interface MemoryDevice {
   read8(addr: number): number;
@@ -51,6 +51,9 @@ export type ChipsetTraceHook = (trace: ChipsetCycleTrace) => void;
 export interface Chipset {
   attachCpu(cpu: Z80Core): void;
   tick(tstates: number): void;
+  getLastPinsOut(): Z80PinsOut;
+  getLastPinsIn(): Z80PinsIn;
+  getLastIntDataBus(): number;
 }
 
 export interface CpuStateProvider {

--- a/packages/machine-pcg815/src/machine.ts
+++ b/packages/machine-pcg815/src/machine.ts
@@ -1,4 +1,4 @@
-import type { CpuState } from '@z80emu/core-z80';
+import type { CpuState, Z80PinsOut } from '@z80emu/core-z80';
 import { Z80Cpu } from '@z80emu/core-z80';
 import { BasicChipset, type IoDevice, type MemoryDevice } from '@z80emu/machine-chipsets';
 import {
@@ -31,6 +31,7 @@ import {
 import { KEY_MAP_BY_CODE } from './keyboard-map';
 import type {
   BasicEngineStatus,
+  CpuPinsInSnapshot,
   FirmwareIoStats,
   MachinePCG815,
   PCG815ExecutionBackend,
@@ -718,6 +719,23 @@ export class PCG815Machine implements MachinePCG815, MemoryDevice, IoDevice {
 
   getCpuState(): CpuState {
     return this.chipset.getCpuState();
+  }
+
+  getCpuPinsOut(): Z80PinsOut {
+    return this.chipset.getLastPinsOut();
+  }
+
+  getCpuPinsIn(): CpuPinsInSnapshot {
+    const pinsIn = this.chipset.getLastPinsIn();
+    return {
+      wait: Boolean(pinsIn.wait),
+      int: Boolean(pinsIn.int),
+      nmi: Boolean(pinsIn.nmi),
+      busrq: Boolean(pinsIn.busrq),
+      reset: Boolean(pinsIn.reset),
+      intDataBus: this.chipset.getLastIntDataBus() & 0xff,
+      data: pinsIn.data & 0xff
+    };
   }
 
   getRamRange(): { start: number; end: number } {

--- a/packages/machine-pcg815/src/types.ts
+++ b/packages/machine-pcg815/src/types.ts
@@ -1,4 +1,4 @@
-import type { CpuState } from '@z80emu/core-z80';
+import type { CpuState, Z80PinsOut } from '@z80emu/core-z80';
 import type { MonitorRuntimeSnapshot } from '@z80emu/firmware-monitor';
 
 export type PCG815ExecutionBackend = 'z80-firmware' | 'ts-compat';
@@ -21,6 +21,16 @@ export interface BasicEngineStatus {
   basicRamEnd: number;
   executionBackend: PCG815ExecutionBackend;
   executionDomain: PCG815ExecutionDomain;
+}
+
+export interface CpuPinsInSnapshot {
+  wait: boolean;
+  int: boolean;
+  nmi: boolean;
+  busrq: boolean;
+  reset: boolean;
+  intDataBus: number;
+  data: number;
 }
 
 // 永続化用スナップショットの現行フォーマット。
@@ -67,6 +77,9 @@ export interface MachinePCG815 {
   isRuntimeProgramRunning(): boolean;
   getFrameBuffer(): Uint8Array;
   getFrameRevision(): number;
+  getCpuState(): CpuState;
+  getCpuPinsOut(): Z80PinsOut;
+  getCpuPinsIn(): CpuPinsInSnapshot;
   reset(cold: boolean): void;
   loadProgram(bytes: Uint8Array | readonly number[], origin: number): void;
   setProgramCounter(entry: number): void;


### PR DESCRIPTION
## Summary
- redesign the machine monitor UI for always-on visibility and improved readability
- add CPU pin snapshot APIs from machine/chipset layers to power structured monitor cards
- show main + shadow registers, address/data bus, and pin H/L indicators in a stable layout
- move monitor below the device panel and keep Input Log inside the monitor section
- refresh monitor styling to a high-contrast gaming-style HUD and tune sizing/overflow behavior

## Changes
- `packages/machine-chipsets`: expose latest pins out/in snapshots and interrupt data bus
- `packages/machine-pcg815`: expose `getCpuPinsOut()` and `getCpuPinsIn()` from public machine API
- `apps/web/src/main.ts`: replace JSON debug dump with structured monitor rendering and compact tick formatting
- `apps/web/index.html`: add dedicated machine monitor structure and relocate monitor block under device panel
- `apps/web/src/styles.css`: redesign monitor visuals, spacing, chip sizing, and readability
- `apps/web/tests/smoke.spec.ts`: add/update monitor visibility and layout assertions; stabilize first smoke timeout

## Testing
- `npm test`
- `npm run test:e2e -w @z80emu/web`
